### PR TITLE
🧹 [code health improvement] Replace bare exceptions with OSError in mission manager

### DIFF
--- a/src/askgem/core/mission_manager.py
+++ b/src/askgem/core/mission_manager.py
@@ -6,6 +6,7 @@ high-level goals and "missions" for the agent.
 """
 
 import os
+
 from .paths import get_heartbeat_path
 
 DEFAULT_HEARTBEAT_TEMPLATE = """# AskGem Active Missions
@@ -39,9 +40,9 @@ class MissionManager:
             str: The raw markdown content.
         """
         try:
-            with open(self.path, "r", encoding="utf-8") as f:
+            with open(self.path, encoding="utf-8") as f:
                 return f.read()
-        except Exception:
+        except OSError:
             return ""
 
     def add_task(self, task: str) -> bool:
@@ -55,13 +56,13 @@ class MissionManager:
         """
         content = self.read_missions()
         lines = content.splitlines()
-        
+
         target_index = -1
         for i, line in enumerate(lines):
             if line.strip().lower() == "## tasks":
                 target_index = i
                 break
-        
+
         if target_index != -1:
             lines.insert(target_index + 1, f"- [ ] {task}")
         else:
@@ -72,7 +73,7 @@ class MissionManager:
             with open(self.path, "w", encoding="utf-8") as f:
                 f.write("\n".join(lines))
             return True
-        except Exception:
+        except OSError:
             return False
 
     def complete_task(self, task: str) -> bool:
@@ -87,17 +88,17 @@ class MissionManager:
         content = self.read_missions()
         lines = content.splitlines()
         updated = False
-        
+
         for i, line in enumerate(lines):
             if task.lower() in line.lower() and "[ ]" in line:
                 lines[i] = line.replace("[ ]", "[x]")
                 updated = True
-        
+
         if updated:
             try:
                 with open(self.path, "w", encoding="utf-8") as f:
                     f.write("\n".join(lines))
                 return True
-            except Exception:
+            except OSError:
                 return False
         return False

--- a/tests/test_mission_manager.py
+++ b/tests/test_mission_manager.py
@@ -49,7 +49,7 @@ def test_read_missions_exception(mock_heartbeat_path):
     manager = MissionManager()
 
     # Force an exception by mocking open to raise an error
-    with patch('builtins.open', side_effect=Exception("Read error")):
+    with patch('builtins.open', side_effect=OSError("Read error")):
         content = manager.read_missions()
 
     assert content == ""
@@ -98,7 +98,7 @@ def test_add_task_write_exception(mock_heartbeat_path):
     original_open = open
     def mock_open_func(*args, **kwargs):
         if 'w' in (args[1] if len(args) > 1 else kwargs.get('mode', 'r')):
-            raise Exception("Write error")
+            raise OSError("Write error")
         return original_open(*args, **kwargs)
 
     with patch('builtins.open', side_effect=mock_open_func):
@@ -148,7 +148,7 @@ def test_complete_task_write_exception(mock_heartbeat_path):
     original_open = open
     def mock_open_func(*args, **kwargs):
         if 'w' in (args[1] if len(args) > 1 else kwargs.get('mode', 'r')):
-            raise Exception("Write error")
+            raise OSError("Write error")
         return original_open(*args, **kwargs)
 
     with patch('builtins.open', side_effect=mock_open_func):


### PR DESCRIPTION
🎯 **What:** Replaced `except Exception:` with `except OSError:` in `src/askgem/core/mission_manager.py`.
💡 **Why:** Catching bare exceptions can mask unintended errors (e.g., typos, type errors). Since the errors to be caught are specifically related to file read/write issues, `OSError` is the correct, standard exception in Python 3.
✅ **Verification:** Updated mock exceptions in `tests/test_mission_manager.py` to raise `OSError` instead of base `Exception`. Ran `pytest` ensuring all test cases pass without regressions. Run `ruff` and resolved all lints.
✨ **Result:** Improved robustness, maintainability, and readability of file I/O operations inside `mission_manager.py`.

---
*PR created automatically by Jules for task [7721112037642338980](https://jules.google.com/task/7721112037642338980) started by @julesklord*