### PR TITLE
🧹 [Code Health] Replace bare except Exception with OSError in MissionManager

### DIFF
--- a/src/askgem/core/mission_manager.py
+++ b/src/askgem/core/mission_manager.py
@@ -41,7 +41,7 @@ class MissionManager:
         try:
             with open(self.path, "r", encoding="utf-8") as f:
                 return f.read()
-        except Exception:
+        except OSError:
             return ""
 
     def add_task(self, task: str) -> bool:
@@ -72,7 +72,7 @@ class MissionManager:
             with open(self.path, "w", encoding="utf-8") as f:
                 f.write("\n".join(lines))
             return True
-        except Exception:
+        except OSError:
             return False
 
     def complete_task(self, task: str) -> bool:
@@ -98,6 +98,6 @@ class MissionManager:
                 with open(self.path, "w", encoding="utf-8") as f:
                     f.write("\n".join(lines))
                 return True
-            except Exception:
+            except OSError:
                 return False
         return False

--- a/tests/test_mission_manager.py
+++ b/tests/test_mission_manager.py
@@ -49,7 +49,7 @@ def test_read_missions_exception(mock_heartbeat_path):
     manager = MissionManager()
 
     # Force an exception by mocking open to raise an error
-    with patch('builtins.open', side_effect=Exception("Read error")):
+    with patch('builtins.open', side_effect=OSError("Read error")):
         content = manager.read_missions()
 
     assert content == ""
@@ -98,7 +98,7 @@ def test_add_task_write_exception(mock_heartbeat_path):
     original_open = open
     def mock_open_func(*args, **kwargs):
         if 'w' in (args[1] if len(args) > 1 else kwargs.get('mode', 'r')):
-            raise Exception("Write error")
+            raise OSError("Write error")
         return original_open(*args, **kwargs)
 
     with patch('builtins.open', side_effect=mock_open_func):
@@ -148,7 +148,7 @@ def test_complete_task_write_exception(mock_heartbeat_path):
     original_open = open
     def mock_open_func(*args, **kwargs):
         if 'w' in (args[1] if len(args) > 1 else kwargs.get('mode', 'r')):
-            raise Exception("Write error")
+            raise OSError("Write error")
         return original_open(*args, **kwargs)
 
     with patch('builtins.open', side_effect=mock_open_func):


### PR DESCRIPTION
🎯 **What:** Replaced `except Exception:` with `except OSError:` in the file I/O operations of `src/askgem/core/mission_manager.py` (`read_missions`, `add_task`, `complete_task`). Also updated tests in `tests/test_mission_manager.py` to raise `OSError` instead of generic `Exception`.
💡 **Why:** Catching broad exceptions like `Exception` can swallow unexpected errors (e.g., `KeyboardInterrupt`, `NameError`). Using `OSError` is the modern, idiomatic choice for handling file-related system errors, making the code more robust and maintainable.
✅ **Verification:** Ran pytest on `tests/test_mission_manager.py` after updating the mocked exceptions. Tests passed. Ran a full pytest suite after resolving a few missing dependency errors.
✨ **Result:** Improved codebase health and robustness around file I/O in the `MissionManager`.

---
*PR created automatically by Jules for task [2227900452455321542](https://jules.google.com/task/2227900452455321542) started by @julesklord*