### PR TITLE
🧹 Remove unused imports in system_tools.py

### DIFF
--- a/src/askgem/tools/system_tools.py
+++ b/src/askgem/tools/system_tools.py
@@ -6,11 +6,9 @@ It does NOT handle interactive terminal sessions or streaming stdio.
 """
 
 import asyncio
-import os
+import contextlib
 import platform
-import shlex
 import shutil
-import subprocess
 
 
 def _get_shell_args(command: str) -> dict:
@@ -76,10 +74,8 @@ async def execute_bash(command: str) -> str:
             # wait_for returns (stdout, stderr) after process finishes
             stdout_data, stderr_data = await asyncio.wait_for(process.communicate(), timeout=60)
         except asyncio.TimeoutError:
-            try:
+            with contextlib.suppress(Exception):
                 process.kill()
-            except Exception:
-                pass
             return f"Error: Command '{command}' timed out after 60 seconds."
 
         # Decoding


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`os`, `shlex`, `subprocess`) from `src/askgem/tools/system_tools.py` and refactored an error-handling block to use `contextlib.suppress`.
💡 **Why:** Cleaning up the namespace and using modern, idiomatic Python patterns improves code maintainability and readability.
✅ **Verification:**
  - Ran `ruff check` to ensure all unused imports and linting issues are resolved.
  - Ran `pytest tests/test_system_tools.py` to confirm that command execution logic remains functional.
✨ **Result:** A cleaner and more idiomatic `system_tools.py` module.

---
*PR created automatically by Jules for task [3384629134279624848](https://jules.google.com/task/3384629134279624848) started by @julesklord*