### PR TITLE
🔒 [security fix] Path Traversal Bypass in file tools

### DIFF
--- a/src/askgem/tools/file_tools.py
+++ b/src/askgem/tools/file_tools.py
@@ -25,7 +25,7 @@ def _ensure_safe_path(path: str) -> str:
     """
     abs_path = os.path.abspath(path)
     cwd = os.getcwd()
-    if not abs_path.startswith(cwd):
+    if os.path.commonpath([cwd, abs_path]) != cwd:
         raise PermissionError(
             f"Access denied: Path '{path}' is outside the allowed directory."
         )

--- a/tests/test_security_file_tools.py
+++ b/tests/test_security_file_tools.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+from askgem.tools.file_tools import _ensure_safe_path
+
+def test_path_traversal_prefix_bypass(tmp_path, monkeypatch):
+    """
+    Test that _ensure_safe_path correctly blocks access to paths that
+    happen to share a string prefix with the current working directory
+    but are actually outside of it.
+    """
+    # Setup:
+    # /tmp/pytest-of-user/pytest-0/test_path_traversal_prefix_bypass0/app
+    # /tmp/pytest-of-user/pytest-0/test_path_traversal_prefix_bypass0/app_secret
+
+    base_dir = tmp_path / "app"
+    secret_dir = tmp_path / "app_secret"
+    base_dir.mkdir()
+    secret_dir.mkdir()
+
+    secret_file = secret_dir / "secret.txt"
+    secret_file.write_text("sensitive data")
+
+    # Change CWD to the app directory
+    monkeypatch.chdir(base_dir)
+
+    # This path is OUTSIDE the CWD, but its absolute path starts with CWD as a string.
+    # Vulnerable code: abs_path.startswith(cwd)
+    # /.../app_secret/secret.txt starts with /.../app
+    malicious_path = str(secret_file)
+
+    # This should RAISE PermissionError.
+    # If the vulnerability is present, it will NOT raise.
+    with pytest.raises(PermissionError) as excinfo:
+        _ensure_safe_path(malicious_path)
+
+    assert "outside the allowed directory" in str(excinfo.value)
+
+def test_ensure_safe_path_normal_behavior(tmp_path, monkeypatch):
+    """Ensure that legitimate paths are still allowed."""
+    base_dir = tmp_path / "app"
+    base_dir.mkdir()
+
+    file_in_base = base_dir / "valid.txt"
+    file_in_base.write_text("safe content")
+
+    monkeypatch.chdir(base_dir)
+
+    # Relative path
+    assert _ensure_safe_path("valid.txt") == str(file_in_base)
+
+    # Absolute path
+    assert _ensure_safe_path(str(file_in_base)) == str(file_in_base)
+
+    # Subdirectory
+    sub_dir = base_dir / "subdir"
+    sub_dir.mkdir()
+    file_in_sub = sub_dir / "sub.txt"
+    file_in_sub.write_text("more safe content")
+
+    assert _ensure_safe_path("subdir/sub.txt") == str(file_in_sub)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Path Traversal Bypass in `_ensure_safe_path` within `src/askgem/tools/file_tools.py`.
⚠️ **Risk:** Unauthorized file access to directories that share a common string prefix with the current working directory (CWD). An attacker could potentially read or modify sensitive files in sibling directories.
🛡️ **Solution:** Switched from a raw string `startswith` check to `os.path.commonpath([cwd, abs_path]) == cwd`, which correctly handles directory boundaries. Added `tests/test_security_file_tools.py` to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [15015521718570259787](https://jules.google.com/task/15015521718570259787) started by @julesklord*