### PR TITLE
🔒 Fix Server-Side Request Forgery (SSRF) vulnerability in web_fetch

### DIFF
--- a/src/askgem/tools/web_tools.py
+++ b/src/askgem/tools/web_tools.py
@@ -1,6 +1,8 @@
 import asyncio
+import ipaddress
 import json
 import re
+import socket
 import urllib.parse
 import urllib.request
 from typing import Optional
@@ -40,7 +42,7 @@ async def _google_search(query: str, api_key: str, cx_id: str) -> str:
         items = await asyncio.to_thread(_do_google_search)
 
         if not items:
-                return "No se encontraron resultados en Google."
+            return "No se encontraron resultados en Google."
 
         results = ["[RESULTADOS DE BÚSQUEDA (GOOGLE)]"]
         for i, item in enumerate(items[:5], 1):
@@ -61,6 +63,7 @@ async def _duckduckgo_search(query: str) -> str:
         url = f"https://html.duckduckgo.com/html/?q={safe_query}"
 
         req = urllib.request.Request(url, headers={"User-Agent": user_agent})
+
         def _do_ddg_search():
             with urllib.request.urlopen(req, timeout=10) as response:
                 return response.read().decode("utf-8")
@@ -87,15 +90,45 @@ async def _duckduckgo_search(query: str) -> str:
             count += 1
 
         if count == 0:
-            return "No se encontraron resultados en DuckDuckGo. Por favor revisa tu conexión o intenta con otra consulta."
+            return (
+                "No se encontraron resultados en DuckDuckGo. Por favor revisa tu conexión o intenta con otra consulta."
+            )
 
         return "\n".join(results)
     except Exception as e:
         return f"Error en búsqueda de DuckDuckGo: {str(e)}"
 
 
+def is_safe_url(url: str) -> bool:
+    """
+    Checks if a URL is safe to fetch (prevents SSRF).
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        # Resolve IP
+        addr_info = socket.getaddrinfo(hostname, parsed.port or 80)
+        for info in addr_info:
+            ip_str = info[4][0]
+            ip = ipaddress.ip_address(ip_str)
+            if ip.is_loopback or ip.is_private or not ip.is_global:
+                return False
+        return True
+    except Exception:
+        return False
+
+
 async def web_fetch(url: str) -> str:
     """Fetches a URL and returns cleaned text content."""
+    if not is_safe_url(url):
+        return f"Error: URL '{url}' is invalid or blocked for security reasons."
+
     try:
         user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
         req = urllib.request.Request(url, headers={"User-Agent": user_agent})

--- a/tests/test_web_tools.py
+++ b/tests/test_web_tools.py
@@ -4,21 +4,25 @@ Unit tests for the web research tools (Google Search & DuckDuckGo).
 
 import asyncio
 import json
+import socket
 from unittest.mock import MagicMock, patch
+
 import pytest
 
-from src.askgem.tools.web_tools import web_fetch, web_search
+from src.askgem.tools.web_tools import is_safe_url, web_fetch, web_search
 
 
 @pytest.fixture
 def mock_google_response():
     """Mock JSON response for Google Custom Search."""
-    return json.dumps({
-        "items": [
-            {"title": "Result 1", "link": "https://example.com/1", "snippet": "Snippet 1"},
-            {"title": "Result 2", "link": "https://example.com/2", "snippet": "Snippet 2"}
-        ]
-    }).encode("utf-8")
+    return json.dumps(
+        {
+            "items": [
+                {"title": "Result 1", "link": "https://example.com/1", "snippet": "Snippet 1"},
+                {"title": "Result 2", "link": "https://example.com/2", "snippet": "Snippet 2"},
+            ]
+        }
+    ).encode("utf-8")
 
 
 @pytest.fixture
@@ -58,7 +62,7 @@ def test_web_fetch_html_cleaning(mock_url_open, mock_html_page):
     mock_response = MagicMock()
     mock_response.read.return_value = mock_html_page
     # Mock response.headers.get('Content-Type', '').lower()
-    mock_response.headers.get.side_effect = lambda k, d="": "text/html" if k == 'Content-Type' else d
+    mock_response.headers.get.side_effect = lambda k, d="": "text/html" if k == "Content-Type" else d
     mock_response.__enter__.return_value = mock_response
     mock_url_open.return_value = mock_response
 
@@ -76,10 +80,47 @@ def test_web_fetch_truncation():
     with patch("urllib.request.urlopen") as mock_url_open:
         mock_response = MagicMock()
         mock_response.read.return_value = long_text.encode("utf-8")
-        mock_response.headers.get.side_effect = lambda k, d="": "text/plain" if k == 'Content-Type' else d
+        mock_response.headers.get.side_effect = lambda k, d="": "text/plain" if k == "Content-Type" else d
         mock_response.__enter__.return_value = mock_response
         mock_url_open.return_value = mock_response
 
         content = asyncio.run(web_fetch("https://example.com"))
         assert len(content) <= 4100  # 4000 + notice
         assert "CONTENIDO TRUNCADO" in content
+
+
+@patch("src.askgem.tools.web_tools.socket.getaddrinfo")
+def test_is_safe_url_unsafe(mock_getaddrinfo):
+    """Verifies that is_safe_url rejects private/loopback/non-global IPs."""
+    # Mock loopback IP
+    mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))]
+    assert is_safe_url("http://localhost") is False
+    assert is_safe_url("http://127.0.0.1") is False
+
+    # Mock private IP
+    mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 80))]
+    assert is_safe_url("http://192.168.1.1") is False
+
+    # Mock link-local IP
+    mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+    assert is_safe_url("http://169.254.169.254") is False
+
+    # Invalid schemes
+    assert is_safe_url("file:///etc/passwd") is False
+    assert is_safe_url("ftp://example.com") is False
+
+
+@patch("src.askgem.tools.web_tools.socket.getaddrinfo")
+def test_is_safe_url_safe(mock_getaddrinfo):
+    """Verifies that is_safe_url accepts global IPs."""
+    # Mock global IP
+    mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))]
+    assert is_safe_url("https://google.com") is True
+
+
+@patch("src.askgem.tools.web_tools.is_safe_url")
+def test_web_fetch_ssrf_prevention(mock_is_safe_url):
+    """Verifies that web_fetch rejects unsafe URLs."""
+    mock_is_safe_url.return_value = False
+    content = asyncio.run(web_fetch("http://localhost"))
+    assert "Error: URL 'http://localhost' is invalid or blocked for security reasons." in content


### PR DESCRIPTION
🎯 **What:** The `web_fetch` function in `src/askgem/tools/web_tools.py` was vulnerable to Server-Side Request Forgery (SSRF), allowing it to potentially access and read data from local or internal resources (e.g., `localhost`, `127.0.0.1`, AWS metadata endpoints like `169.254.169.254`, or private LAN networks).

⚠️ **Risk:** An attacker could supply malicious URLs that point to internal system IP addresses or loopback interfaces, giving them a gateway to leak sensitive metadata, access internal APIs, or pivot into restricted subnets since the backend would blindly execute requests to them.

🛡️ **Solution:** Added a strict IP validation function `is_safe_url`. This function uses Python's `socket.getaddrinfo` to resolve the underlying IP addresses for the supplied hostname, and employs the `ipaddress` library to ensure that any resolved IP is not a loopback address, a private address, and is generally a globally routable public IP. If the validation fails, the system blocks the fetch operation. Test coverage has been added to ensure known vulnerable IP spaces are rejected.

---
*PR created automatically by Jules for task [7788283722635724093](https://jules.google.com/task/7788283722635724093) started by @julesklord*