### PR TITLE
🔒 Remove unencrypted legacy API key fallback

### DIFF
--- a/src/askgem/core/config_manager.py
+++ b/src/askgem/core/config_manager.py
@@ -102,22 +102,15 @@ class ConfigManager:
                 "[warning][!] Keyring is unavailable. You can set the 'GOOGLE_API_KEY' environment variable as a fallback.[/warning]"
             )
 
-        # 3. Unencrypted local file (v1 base legacy fallback)
+        # 3. Unencrypted local file (v1 base legacy fallback) - Removed for security
         path = get_config_path(self.UNENCRYPTED_API_KEY_FILE)
         if os.path.exists(path):
-            try:
-                with open(path) as key_file:
-                    api_key = key_file.read().strip()
-                    if api_key:
-                        self.console.print(
-                            f"[warning][!] API Key loaded from unencrypted file:[/warning] [google.blue]{path}[/google.blue]"
-                        )
-                        self.console.print(
-                            "[warning][!] Consider running 'askgem auth' to secure it in system keyring.[/warning]"
-                        )
-                        return api_key
-            except OSError as e:
-                self.console.print(f"[error][X] Error loading API Key from file:[/error] {e}")
+            self.console.print(
+                f"[error][!] SECURITY WARNING: Legacy unencrypted API key file detected at {path}[/error]"
+            )
+            self.console.print(
+                "[error][!] This file is no longer used. Please delete it immediately and run 'askgem auth' to secure your key in the system keyring.[/error]"
+            )
 
         return None
 
@@ -139,8 +132,8 @@ class ConfigManager:
             # If legacy file exists, warn the user
             path = get_config_path(self.UNENCRYPTED_API_KEY_FILE)
             if os.path.exists(path):
-                self.console.print(f"[warning][!] Legacy unencrypted file still exists at: {path}[/warning]")
-                self.console.print("[warning][!] You may want to delete it manually for better security.[/warning]")
+                self.console.print(f"[error][!] SECURITY WARNING: Legacy unencrypted file still exists at: {path}[/error]")
+                self.console.print("[error][!] You MUST delete it manually for better security.[/error]")
 
             return True
         except Exception as e:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -94,10 +94,39 @@ class TestConfigManagerApiKey:
             cm = ConfigManager(_mock_console)
             assert cm.load_api_key() is None
 
+    def test_returns_none_and_warns_when_legacy_file_exists(self, tmp_path):
+        with patch.dict(os.environ, {}, clear=True), patch("askgem.core.config_manager.get_config_path") as mock_path:
+            # Create a mock legacy unencrypted key file
+            key_file = tmp_path / ".gemini_api_key_unencrypted"
+            key_file.write_text("insecure-key")
+            # When the code looks for settings.json it might use the same mock,
+            # so let's use side_effect to route correctly.
+            def mock_path_side_effect(filename):
+                if filename == ConfigManager.UNENCRYPTED_API_KEY_FILE:
+                    return str(key_file)
+                return f"/tmp/{filename}"
+
+            mock_path.side_effect = mock_path_side_effect
+
+            # Reset the mock console calls to isolate from init output
+            _mock_console.print.reset_mock()
+
+            # Keyring should return None for test isolation
+            with patch("keyring.get_password", return_value=None):
+                cm = ConfigManager(_mock_console)
+                _mock_console.print.reset_mock()
+
+                # It should not return the insecure key
+                assert cm.load_api_key() is None
+                # Check that the console received a security warning
+                _mock_console.print.assert_called()
+                calls = [call.args[0] for call in _mock_console.print.call_args_list]
+                assert any("SECURITY WARNING" in str(arg) for arg in calls)
+
     def test_saves_and_loads_api_key(self, tmp_path):
-        with patch.dict(os.environ, {}, clear=True), patch("askgem.core.paths.get_config_path") as mock_path:
-            key_file = str(tmp_path / ".gemini_api_key_unencrypted")
-            mock_path.return_value = key_file
+        with patch.dict(os.environ, {}, clear=True), patch("keyring.set_password") as mock_set, patch("keyring.get_password") as mock_get:
+            mock_get.return_value = "my-test-key"
             cm = ConfigManager(_mock_console)
             cm.save_api_key("my-test-key")
+            mock_set.assert_called_with("askgem", "GOOGLE_API_KEY", "my-test-key")
             assert cm.load_api_key() == "my-test-key"


### PR DESCRIPTION
## Description
🔒 Remove unencrypted legacy API key fallback in ConfigManager

🎯 **What:** Removed the vulnerability in `ConfigManager` where legacy API keys were loaded from an unencrypted file (`.gemini_api_key_unencrypted`).
⚠️ **Risk:** Storing API keys in unencrypted text files leaves users highly vulnerable to key theft, SSRF, and credential dumping by anyone or any tool reading user directories.
🛡️ **Solution:** `load_api_key` now completely skips reading the legacy file and instead prints a critical `SECURITY WARNING` instructing the user to delete it and to utilize `askgem auth` to securely store their keys. The warning about legacy keys during the save process has also been elevated from warning level to an error.

Re-wrote affected tests to check `keyring` storage paths properly.

---
*PR created automatically by Jules for task [202006014659070045](https://jules.google.com/task/202006014659070045) started by @julesklord*