### PR TITLE
🧪 Add tests for identity manager

### DIFF
--- a/src/askgem/core/identity_manager.py
+++ b/src/askgem/core/identity_manager.py
@@ -6,7 +6,7 @@ personality traits, and system role.
 """
 
 import os
-from .paths import get_identity_path
+from .paths import get_config_path
 
 DEFAULT_IDENTITY_TEMPLATE = """# AskGem Identity & Persona
 # This file defines who you are.
@@ -38,7 +38,7 @@ class IdentityManager:
     """Manages the ~/.askgem/identity.md file."""
 
     def __init__(self):
-        self.path = get_identity_path()
+        self.path = get_config_path("identity.md")
         self._ensure_identity_exists()
 
     def _ensure_identity_exists(self):

--- a/tests/test_identity_manager.py
+++ b/tests/test_identity_manager.py
@@ -1,0 +1,98 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from askgem.core.identity_manager import DEFAULT_IDENTITY_TEMPLATE, IdentityManager
+
+
+@pytest.fixture
+def mock_identity_path(tmp_path):
+    identity_file = str(tmp_path / "identity.md")
+    with patch("askgem.core.identity_manager.get_config_path") as mock_path:
+        mock_path.return_value = identity_file
+        yield identity_file
+
+
+def test_init_creates_identity(mock_identity_path):
+    assert not os.path.exists(mock_identity_path)
+
+    IdentityManager()
+
+    assert os.path.exists(mock_identity_path)
+    with open(mock_identity_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert content == DEFAULT_IDENTITY_TEMPLATE
+
+
+def test_init_does_not_overwrite_existing_identity(mock_identity_path):
+    test_content = "Existing identity content"
+    with open(mock_identity_path, "w", encoding="utf-8") as f:
+        f.write(test_content)
+
+    IdentityManager()
+
+    with open(mock_identity_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert content == test_content
+
+
+def test_read_identity(mock_identity_path):
+    manager = IdentityManager()
+
+    test_content = "Some identity content"
+    with open(mock_identity_path, "w", encoding="utf-8") as f:
+        f.write(test_content)
+
+    result = manager.read_identity()
+    assert result == test_content
+
+
+def test_read_identity_handles_error(mock_identity_path):
+    manager = IdentityManager()
+
+    # To trigger the exception in read_identity, we can patch open
+    original_open = open
+
+    def mock_open(*args, **kwargs):
+        if len(args) > 1 and args[1] == "r":
+            raise OSError("Mocked error")
+        return original_open(*args, **kwargs)
+
+    with patch("builtins.open", side_effect=mock_open):
+        result = manager.read_identity()
+
+    assert result == "Error al leer la identidad."
+
+
+def test_update_identity(mock_identity_path):
+    manager = IdentityManager()
+
+    new_content = "New identity content"
+    success = manager.update_identity(new_content)
+
+    assert success is True
+
+    with open(mock_identity_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert content == new_content
+
+
+def test_update_identity_handles_error(mock_identity_path):
+    manager = IdentityManager()
+
+    # To trigger the exception in update_identity, we can patch open
+    original_open = open
+
+    def mock_open(*args, **kwargs):
+        if len(args) > 1 and args[1] == "w":
+            raise OSError("Mocked error")
+        return original_open(*args, **kwargs)
+
+    with patch("builtins.open", side_effect=mock_open):
+        success = manager.update_identity("Some content")
+
+    assert success is False


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `IdentityManager` module (`identity_manager.py`). This addresses a testing gap where the core identity management capabilities (creating, reading, and updating the `identity.md` file) were untested.

📊 **Coverage:** The new tests cover:
- Successful instantiation and initial file creation when missing (`test_init_creates_identity`).
- Skipping file creation when `identity.md` already exists (`test_init_does_not_overwrite_existing_identity`).
- Successful reading of file content (`test_read_identity`).
- Graceful error handling and default strings returned when reading fails (`test_read_identity_handles_error`).
- Successful updating of the file content (`test_update_identity`).
- Graceful error handling when updating fails (`test_update_identity_handles_error`).
- Fixed a buggy import call in `identity_manager.py` that referenced an undefined function `get_identity_path` and pointed it to `get_config_path('identity.md')` as intended.

✨ **Result:** Core identity logic is fully covered by tests and file interactions are properly mocked, enabling confident refactoring without risk of breaking persona persistence.

---
*PR created automatically by Jules for task [7342362424758777333](https://jules.google.com/task/7342362424758777333) started by @julesklord*