### PR TITLE
🎨 Palette: Add Busy State to Input in TUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-05 - [Add Busy State to Input in TUI]
+**Learning:** In TUI applications using Textual, interactive widgets like `Input` should be explicitly disabled during asynchronous operations (like streaming an AI response). This provides immediate visual feedback of the "busy" state and prevents users from accidentally submitting concurrent inputs, which reduces cognitive load and prevents race conditions.
+**Action:** Always disable inputs during async agent turns, and remember to re-enable and explicitly refocus them in a `finally` block to restore usability once the process completes.

--- a/src/askgem/cli/dashboard.py
+++ b/src/askgem/cli/dashboard.py
@@ -334,6 +334,9 @@ class AskGemDashboard(App):
         mascot = self.query_one(MascotWidget)
         mascot.set_state("thinking")
 
+        prompt_input = self.query_one("#prompt-input", Input)
+        prompt_input.disabled = True
+
         self.current_response = ""
         self.streaming_response.display = True
 
@@ -357,6 +360,8 @@ class AskGemDashboard(App):
             self.streaming_response.update("")
             # Revert to idle after a delay
             self.set_timer(3.0, lambda: mascot.set_state("idle"))
+            prompt_input.disabled = False
+            prompt_input.focus()
 
     def action_clear(self) -> None:
         """Clears the chat log."""


### PR DESCRIPTION
🎨 **Palette: Add Busy State to Input in TUI**

💡 **What:** The textual `#prompt-input` widget is now explicitly disabled while the agent is processing a turn and re-enabled/focused when finished.
🎯 **Why:** Prevents the user from accidentally submitting concurrent inputs while the app is busy, reducing cognitive load and preventing race conditions in the UI state.
♿ **Accessibility:** Provides clear visual state changes for users relying on the TUI, showing them exactly when it is safe and possible to input the next message.
📸 **Before/After:** The input field visually grays out and is unresponsive while AskGem is thinking, and immediately unlocks and grabs focus back once the response is fully generated.

---
*PR created automatically by Jules for task [17963387064046752875](https://jules.google.com/task/17963387064046752875) started by @julesklord*