### PR TITLE
🎨 Palette: [Preserve Error State in TUI]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2025-05-18 - [Add Busy State during Application Initialization]
 **Learning:** Application startup sequences in Textual applications can lead to race conditions if the inputs are not explicitly disabled before they have fully loaded. Since `init_api` performs network calls and loads chat history asynchronously, it can result in inputs being processed before initialization completes.
 **Action:** Always explicitly disable interactive inputs at the beginning of asynchronous initialization sequences and remember to re-enable and explicitly refocus them inside a `finally` block.
+## 2026-04-07 - [Preserve Error Visual Feedback]
+**Learning:** When resetting TUI widget states (like 'idle') in a `finally` block after an asynchronous operation, conditionally check that the state isn't already set to 'error'. Blindly resetting state clears critical visual error feedback, confusing users.
+**Action:** Always verify the current state is not 'error' before reverting a widget to 'idle' during a cleanup/finally phase.

--- a/src/askgem/cli/dashboard.py
+++ b/src/askgem/cli/dashboard.py
@@ -412,7 +412,7 @@ class AskGemDashboard(App):
             self.streaming_response.display = False
             self.streaming_response.update("")
             # Revert to idle after a delay
-            self.set_timer(3.0, lambda: mascot.set_state("idle"))
+            self.set_timer(3.0, lambda: mascot.set_state("idle") if mascot.state != "error" else None)
             prompt_input.disabled = False
             prompt_input.focus()
 


### PR DESCRIPTION
💡 **What:** Added a conditional check so the mascot only reverts to the "idle" state if it wasn't already in an "error" state.\n🎯 **Why:** Previously, the unconditional timer reset the state to idle after 3 seconds, meaning if an error happened right before, the user would lose the visual error indication too quickly, causing confusion.\n📸 **Before/After:** Not applicable (behavioral UX change).\n♿ **Accessibility:** Ensures errors persist visually so users have enough time to notice and read them.

---
*PR created automatically by Jules for task [6319414668591106183](https://jules.google.com/task/6319414668591106183) started by @julesklord*