### PR TITLE
🎨 Palette: Preserve mascot visual error state after operations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-18 - [Add Busy State during Application Initialization]
 **Learning:** Application startup sequences in Textual applications can lead to race conditions if the inputs are not explicitly disabled before they have fully loaded. Since `init_api` performs network calls and loads chat history asynchronously, it can result in inputs being processed before initialization completes.
 **Action:** Always explicitly disable interactive inputs at the beginning of asynchronous initialization sequences and remember to re-enable and explicitly refocus them inside a `finally` block.
+
+## 2025-05-24 - [Preserve Visual Error State During Async Operations]
+**Learning:** Automatically resetting visual indicators to an 'idle' state via a timeout in a `finally` block can override critical error states set during the `except` block. This removes visual error feedback before users can fully register the failure, leading to confusion.
+**Action:** When reverting visual states (like a mascot's 'thinking' state) after an operation, always conditionally check that the state isn't already set to an 'error' state before resetting to 'idle'.

--- a/src/askgem/cli/dashboard.py
+++ b/src/askgem/cli/dashboard.py
@@ -411,8 +411,11 @@ class AskGemDashboard(App):
         finally:
             self.streaming_response.display = False
             self.streaming_response.update("")
-            # Revert to idle after a delay
-            self.set_timer(3.0, lambda: mascot.set_state("idle"))
+            # Revert to idle after a delay, unless there was an error
+            def reset_idle():
+                if mascot.state != "error":
+                    mascot.set_state("idle")
+            self.set_timer(3.0, reset_idle)
             prompt_input.disabled = False
             prompt_input.focus()
 


### PR DESCRIPTION
💡 **What**: Conditionally checks if the mascot is in an 'error' state before automatically resetting it to 'idle' in the `finally` block of `run_agent_turn`.
🎯 **Why**: Prevents critical visual error feedback from being overridden by a timeout, ensuring users can properly see when an operation fails.
♿ **Accessibility**: Improves visual feedback continuity for error states, ensuring users with cognitive or visual impairments have time to register failures before the UI resets.

---
*PR created automatically by Jules for task [16034395384767057562](https://jules.google.com/task/16034395384767057562) started by @julesklord*