### PR TITLE
🎨 Palette: Add visual loading state to input placeholder

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-04-07 - [Preserve Error Visual Feedback]
 **Learning:** When resetting TUI widget states (like 'idle') in a `finally` block after an asynchronous operation, conditionally check that the state isn't already set to 'error'. Blindly resetting state clears critical visual error feedback, confusing users.
 **Action:** Always verify the current state is not 'error' before reverting a widget to 'idle' during a cleanup/finally phase.
+
+## 2026-04-09 - [Add Visual Loading State to Placeholder]
+**Learning:** Disabling an input field during async operations prevents interaction, but doesn't clearly communicate *why* it's disabled. Changing the input's placeholder text to a 'thinking/loading' message provides immediate, intuitive feedback.
+**Action:** Always update placeholder text to indicate a loading state alongside disabling inputs during async operations, and ensure it's reverted in the finally block.

--- a/src/askgem/cli/dashboard.py
+++ b/src/askgem/cli/dashboard.py
@@ -222,6 +222,7 @@ class AskGemDashboard(App):
         """Initializes the Gemini API in the background and restores last session."""
         prompt_input = self.query_one("#prompt-input", Input)
         prompt_input.disabled = True
+        prompt_input.placeholder = "AskGem está pensando..."
         mascot = self.query_one(MascotWidget)
         mascot.set_state("thinking")
         self.sidebar.update_context(self.agent.model_name, "Iniciando...")
@@ -256,7 +257,6 @@ class AskGemDashboard(App):
 
                 self.sidebar.update_context(self.agent.model_name, self.agent.edit_mode)
                 self._update_mission_display()
-                self.query_one("#prompt-input", Input).placeholder = "Escribe tu mensaje..."
                 self.chat_log.write(
                     f"\n[success][OK] Conexión establecida con [bold]{self.agent.model_name}[/bold][/success]"
                 )
@@ -277,6 +277,7 @@ class AskGemDashboard(App):
             self.sidebar.update_context("N/A", "Error")
         finally:
             prompt_input = self.query_one("#prompt-input", Input)
+            prompt_input.placeholder = "Escribe tu mensaje..."
             prompt_input.disabled = False
             prompt_input.focus()
             mascot = self.query_one(MascotWidget)
@@ -384,6 +385,7 @@ class AskGemDashboard(App):
 
         prompt_input = self.query_one("#prompt-input", Input)
         prompt_input.disabled = True
+        prompt_input.placeholder = "AskGem está pensando..."
 
         self.current_response = ""
         self.streaming_response.display = True
@@ -413,6 +415,7 @@ class AskGemDashboard(App):
             self.streaming_response.update("")
             # Revert to idle after a delay
             self.set_timer(3.0, lambda: mascot.set_state("idle") if mascot.state != "error" else None)
+            prompt_input.placeholder = "Escribe tu mensaje..."
             prompt_input.disabled = False
             prompt_input.focus()
 


### PR DESCRIPTION
🎨 **Palette:** Add visual loading state to chat input field placeholder

💡 **What:** The UX enhancement added: During asynchronous operations (like when AskGem is thinking or when the API is initializing), the `Input` widget's placeholder text now explicitly says `"AskGem está pensando..."` instead of remaining static while disabled. It reverts back to the standard `"Escribe tu mensaje..."` when the process completes.
🎯 **Why:** The user problem it solves: Simply disabling an input field during an async operation prevents interaction but does not clearly communicate *why* it's disabled or that the system is actively working. Changing the placeholder provides an immediate, intuitive, and visually pleasing loading indicator directly where the user's attention is focused.
♿ **Accessibility:** It reduces cognitive load by providing clear system status feedback, preventing confusion about whether the application has frozen.

---
*PR created automatically by Jules for task [17746392598409794666](https://jules.google.com/task/17746392598409794666) started by @julesklord*