### PR TITLE
🎨 Palette: Localize TUI chat input placeholder loading states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-04-09 - [Add Visual Loading State to Placeholder]
 **Learning:** Disabling an input field during async operations prevents interaction, but doesn't clearly communicate *why* it's disabled. Changing the input's placeholder text to a 'thinking/loading' message provides immediate, intuitive feedback.
 **Action:** Always update placeholder text to indicate a loading state alongside disabling inputs during async operations, and ensure it's reverted in the finally block.
+
+## 2026-04-10 - [Localize UI State Text]
+**Learning:** Hardcoding UI strings (like "AskGem está pensando..." or "Escribe tu mensaje...") during runtime state changes breaks internationalization (i18n) and can result in confusing UX where the application language spontaneously changes based on the state. Additionally, initializing a chat input with an incorrect default placeholder (e.g., "Please enter your API Key") creates a confusing first impression.
+**Action:** Always use the localization function (e.g., `_("dashboard.prompt_thinking")`) when updating UI text dynamically during async operations, and ensure new state strings are properly defined across the supported locale JSON files.

--- a/src/askgem/cli/dashboard.py
+++ b/src/askgem/cli/dashboard.py
@@ -214,7 +214,7 @@ class AskGemDashboard(App):
                 yield self.streaming_response
             self.output_log = RichLog(highlight=True, markup=True, id="output-pane")
             yield self.output_log
-        yield Input(placeholder=_("api.prompt"), id="prompt-input")
+        yield Input(placeholder=_("dashboard.prompt_placeholder"), id="prompt-input")
         yield Footer()
 
     @work(exclusive=True)
@@ -222,7 +222,7 @@ class AskGemDashboard(App):
         """Initializes the Gemini API in the background and restores last session."""
         prompt_input = self.query_one("#prompt-input", Input)
         prompt_input.disabled = True
-        prompt_input.placeholder = "AskGem está pensando..."
+        prompt_input.placeholder = _("dashboard.prompt_thinking")
         mascot = self.query_one(MascotWidget)
         mascot.set_state("thinking")
         self.sidebar.update_context(self.agent.model_name, "Iniciando...")
@@ -277,7 +277,7 @@ class AskGemDashboard(App):
             self.sidebar.update_context("N/A", "Error")
         finally:
             prompt_input = self.query_one("#prompt-input", Input)
-            prompt_input.placeholder = "Escribe tu mensaje..."
+            prompt_input.placeholder = _("dashboard.prompt_placeholder")
             prompt_input.disabled = False
             prompt_input.focus()
             mascot = self.query_one(MascotWidget)
@@ -385,7 +385,7 @@ class AskGemDashboard(App):
 
         prompt_input = self.query_one("#prompt-input", Input)
         prompt_input.disabled = True
-        prompt_input.placeholder = "AskGem está pensando..."
+        prompt_input.placeholder = _("dashboard.prompt_thinking")
 
         self.current_response = ""
         self.streaming_response.display = True
@@ -415,7 +415,7 @@ class AskGemDashboard(App):
             self.streaming_response.update("")
             # Revert to idle after a delay
             self.set_timer(3.0, lambda: mascot.set_state("idle") if mascot.state != "error" else None)
-            prompt_input.placeholder = "Escribe tu mensaje..."
+            prompt_input.placeholder = _("dashboard.prompt_placeholder")
             prompt_input.disabled = False
             prompt_input.focus()
 

--- a/src/askgem/locales/en.json
+++ b/src/askgem/locales/en.json
@@ -7,7 +7,6 @@
   "api.fatal": "The API Key is required to continue. Shutting down.",
   "api.save": "Would you like to save it locally for future use? (Y/n)",
   "sys.context": "You are askgem, a CLI coding agent. OS: {os}. CWD: {cwd}. Use tools to read/edit files. Call read_file before edit_file to see exact indentation. Reply briefly.",
-  
   "tool.spawning": "Running autonomous tool:",
   "tool.action_req": "⚠️  Action Required:",
   "tool.wants_run": "The model wants to run:",
@@ -18,7 +17,6 @@
   "tool.denied.edit": "System Notice: The user denied permission to modify this file.",
   "tool.edit.auto": "=> Auto-approving file edit for '{path}'...",
   "tool.unregistered": "Error: Tool '{name}' is not registered in this environment.",
-
   "engine.rate_limit_hint": "(No response content received — the model may have been rate-limited or the request was filtered.)",
   "engine.api_error": "[X] API Error:",
   "engine.retry": "⚠ API error — retrying ({attempt}/{max}) in {delay}s...",
@@ -26,7 +24,6 @@
   "engine.retry_exhausted": "✘ All {max} retry attempts failed. Your input was NOT consumed — try again.",
   "engine.shutdown": "Shutting down. Farewell!",
   "engine.you": "You:",
-  
   "cmd.unknown": "Unknown command:",
   "cmd.hint_help": "— type [bold]/help[/bold] for available commands.",
   "cmd.help.title": "askgem Commands",
@@ -44,7 +41,6 @@
   "cmd.desc.usage": "Show current session token usage and estimated cost",
   "cmd.desc.stats": "Show a detailed summary of accomplishments in this session",
   "cmd.desc.exit": "Exit askgem",
-
   "cmd.active_model": "Active model:",
   "cmd.model.fetching": "Fetching available generation models from your API key...",
   "cmd.model.available": "Available Gemini models:",
@@ -52,15 +48,12 @@
   "cmd.model.usage": "Usage: /model <model_name>",
   "cmd.model.switched": "Switched to model:",
   "cmd.model.failed": "Failed to switch model:",
-
   "cmd.mode.current": "Current edit mode:",
   "cmd.mode.usage": "Usage: /mode auto  |  /mode manual",
   "cmd.mode.set": "Edit mode set to:",
-
   "cmd.clear.success": "Context cleared.",
   "cmd.clear.subtitle": "The model's memory has been reset. Previous messages are still saved on disk.",
   "cmd.clear.failed": "Failed to clear context:",
-
   "cmd.history.none": "No saved sessions found.",
   "cmd.history.title": "Saved Sessions",
   "cmd.history.subtitle": "To restore one: /history load <session_id>",
@@ -80,5 +73,7 @@
   "cmd.stats.tools": "Tools invoked: {count}",
   "cmd.stats.files": "Files modified: {count}",
   "dashboard.sidebar.context": "Context",
-  "dashboard.sidebar.stats": "Statistics"
+  "dashboard.sidebar.stats": "Statistics",
+  "dashboard.prompt_placeholder": "Type your message...",
+  "dashboard.prompt_thinking": "AskGem is thinking..."
 }

--- a/src/askgem/locales/es.json
+++ b/src/askgem/locales/es.json
@@ -7,7 +7,6 @@
   "api.fatal": "La API Key es obligatoria para continuar. Apagando el sistema.",
   "api.save": "¿Te gustaría guardarla localmente para usos futuros? (Y/n)",
   "sys.context": "Eres askgem, un agente CLI. OS: {os}. CWD: {cwd}. Usa herramientas para leer/editar archivos. Llama a read_file antes de edit_file para ver sangría exacta. Responde brevemente.",
-  
   "tool.spawning": "Ejecutando herramienta autónoma:",
   "tool.action_req": "⚠️  Acción Requerida:",
   "tool.wants_run": "El modelo quiere ejecutar:",
@@ -19,7 +18,6 @@
   "tool.edit.auto": "=> Auto-aprobando la edición en '{path}'...",
   "tool.cmd.auto": "=> Ejecución autónoma (sandbox): '{command}'",
   "tool.unregistered": "Error: La herramienta '{name}' no está registrada en este entorno.",
-
   "engine.rate_limit_hint": "(No se recibió contenido — el modelo podría haber sido limitado por tasa o bloqueado.)",
   "engine.api_error": "[X] Error de la API:",
   "engine.retry": "⚠ Error de API — reintentando ({attempt}/{max}) en {delay}s...",
@@ -27,7 +25,6 @@
   "engine.retry_exhausted": "✘ Los {max} intentos de reintento fallaron. Tu mensaje NO fue consumido — intenta de nuevo.",
   "engine.shutdown": "Apagando. ¡Hasta luego!",
   "engine.you": "Tú:",
-
   "cmd.unknown": "Comando desconocido:",
   "cmd.hint_help": "— escribe [bold]/help[/bold] para ver los comandos disponibles.",
   "cmd.help.title": "Comandos askgem",
@@ -47,7 +44,6 @@
   "cmd.desc.usage": "Mostrar el uso de tokens y el costo estimado de la sesión",
   "cmd.desc.stats": "Mostrar un resumen detallado de logros en esta sesión",
   "cmd.desc.exit": "Salir de askgem",
-
   "cmd.active_model": "Modelo activo:",
   "cmd.model.fetching": "Recuperando modelos disponibles desde tu API key...",
   "cmd.model.available": "Modelos Gemini disponibles:",
@@ -55,19 +51,15 @@
   "cmd.model.usage": "Uso: /model <model_name>",
   "cmd.model.switched": "Se cambió el modelo actual a:",
   "cmd.model.failed": "Hubo un error al cambiar el modelo:",
-
   "cmd.mode.current": "Modo de edición actual:",
   "cmd.mode.usage": "Uso: /mode auto  |  /mode manual",
   "cmd.mode.set": "Modo de edición fijado en:",
-
   "cmd.sandbox.current": "Estado actual del Sandbox:",
   "cmd.sandbox.usage": "Uso: /sandbox on  |  /sandbox off",
   "cmd.sandbox.set": "Modo Sandbox fijado en:",
-
   "cmd.clear.success": "Contexto borrado exitosamente.",
   "cmd.clear.subtitle": "La memoria del modelo ha sido reiniciada. Los mensajes anteriores siguen guardados localmente.",
   "cmd.clear.failed": "Hubo un error al limpiar el contexto:",
-
   "cmd.history.none": "No se encontraron sesiones guardadas.",
   "cmd.history.title": "Sesiones Guardadas",
   "cmd.history.subtitle": "Para restaurar una escribe: /history load <session_id>",
@@ -87,5 +79,7 @@
   "cmd.stats.tools": "Herramientas invocadas: {count}",
   "cmd.stats.files": "Archivos modificados: {count}",
   "dashboard.sidebar.context": "Contexto",
-  "dashboard.sidebar.stats": "Estadísticas"
+  "dashboard.sidebar.stats": "Estadísticas",
+  "dashboard.prompt_placeholder": "Escribe tu mensaje...",
+  "dashboard.prompt_thinking": "AskGem está pensando..."
 }


### PR DESCRIPTION
🎨 Palette: Update input placeholder to use localized loading states

💡 What: Replaced hardcoded Spanish placeholder strings ("AskGem está pensando..." and "Escribe tu mensaje...") in the TUI input widget with properly localized keys (`dashboard.prompt_thinking` and `dashboard.prompt_placeholder`).
🎯 Why: To fix an issue where the chat input placeholder would display incorrect default text ("Please enter your Google API Key") and abruptly switch to hardcoded Spanish during asynchronous operations, breaking the app's internationalization and confusing non-Spanish users.
♿ Accessibility: Ensures that screen readers and non-Spanish users receive consistent, localized context about the application's loading state.

---
*PR created automatically by Jules for task [11959462695577841809](https://jules.google.com/task/11959462695577841809) started by @julesklord*