### PR TITLE
🎨 Palette: Disable input widget during slash commands

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-04-10 - [Localize UI State Text]
 **Learning:** Hardcoding UI strings (like "AskGem está pensando..." or "Escribe tu mensaje...") during runtime state changes breaks internationalization (i18n) and can result in confusing UX where the application language spontaneously changes based on the state. Additionally, initializing a chat input with an incorrect default placeholder (e.g., "Please enter your API Key") creates a confusing first impression.
 **Action:** Always use the localization function (e.g., `_("dashboard.prompt_thinking")`) when updating UI text dynamically during async operations, and ensure new state strings are properly defined across the supported locale JSON files.
+
+## 2026-04-11 - [Disable Input Widget During Slash Commands]
+**Learning:** During mid-conversation slash commands, if the input widget is not disabled, users can type concurrent inputs which might lead to unexpected states or race conditions while the asynchronous operation completes. Providing visual feedback (like a thinking placeholder) makes the app feel more responsive and prevents users from feeling stuck or frustrated.
+**Action:** Always disable inputs during async agent operations, including local mid-conversation slash commands, and ensure they are re-enabled and explicitily refocused in a `finally` block to restore usability once the process completes.

--- a/src/askgem/cli/dashboard.py
+++ b/src/askgem/cli/dashboard.py
@@ -368,11 +368,18 @@ class AskGemDashboard(App):
 
         # Intercept slash commands for local processing
         if user_text.startswith("/"):
-            await self.agent._process_slash_command(user_text)
-            if user_text.lower() == "/clear":
-                self.action_clear()
-            elif user_text.lower() == "/usage":
-                self._update_metrics()
+            event.input.disabled = True
+            event.input.placeholder = _("dashboard.prompt_thinking")
+            try:
+                await self.agent._process_slash_command(user_text)
+                if user_text.lower() == "/clear":
+                    self.action_clear()
+                elif user_text.lower() == "/usage":
+                    self._update_metrics()
+            finally:
+                event.input.placeholder = _("dashboard.prompt_placeholder")
+                event.input.disabled = False
+                event.input.focus()
             return
 
         self.run_agent_turn(user_text)


### PR DESCRIPTION
🎯 **What:** The `Input` widget in the TUI dashboard is now disabled and updated with a "thinking" placeholder during asynchronous slash commands.
⚠️ **Why:** When users type mid-conversation slash commands, an asynchronous operation runs without disabling the input, which allows concurrent typing and creates a race condition.
📸 **Accessibility:** Improves the visual feedback by preventing users from typing while commands are loading and clearly communicating the loading state.

---
*PR created automatically by Jules for task [1416051861149424731](https://jules.google.com/task/1416051861149424731) started by @julesklord*