### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,7 @@
 ﻿name: Security Scan
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/askgem.py/security/code-scanning/1](https://github.com/julesklord/askgem.py/security/code-scanning/1)

To fix this, add an explicit `permissions` block to `.github/workflows/security.yml` at the workflow root so it applies to all jobs (currently just `gitleaks`). The minimal required permission for this workflow is `contents: read`, which allows checkout/read access without granting write scopes. This preserves existing functionality while enforcing least privilege and satisfying CodeQL.

Change region:
- `.github/workflows/security.yml`: directly after `on:` (or after `name:`/`on:` section), add:
  - `permissions:`
  - `  contents: read`

No imports, methods, or dependency changes are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
