### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/askgem.py/security/code-scanning/3](https://github.com/julesklord/askgem.py/security/code-scanning/3)

Add an explicit `permissions` block to the `build` job in `.github/workflows/deploy.yml`, since this is the only job currently missing one.  
Best minimal fix without changing behavior: set:

- `contents: read`

This is sufficient for `actions/checkout@v4` and keeps the job least-privileged. No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
