### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,5 +1,7 @@
 ﻿name: Python CI (Pro)
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/askgem.py/security/code-scanning/4](https://github.com/julesklord/askgem.py/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access. For this workflow, `contents: read` is the minimal and sufficient permission for `actions/checkout` and running CI tasks. This preserves current functionality while preventing unintended write scopes if repo/org defaults change.

Edit only `.github/workflows/python-ci.yml`, immediately after the `on:` line (or before `jobs:`), and add:

- `permissions:`
- `contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
