### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/askgem.py/security/code-scanning/5](https://github.com/julesklord/askgem.py/security/code-scanning/5)

Add an explicit `permissions` block to the workflow (or the specific `release` job) so `GITHUB_TOKEN` has least privilege required for this pipeline.

Best fix here without changing behavior: define job-level permissions for `release`:
- `contents: write` (required to create a GitHub release and upload release assets)
- no extra scopes granted.

Edit `.github/workflows/release.yml` in the `jobs.release` section, directly under `runs-on` (or before `steps`) to keep scope tight to this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
