### PR TITLE
🔒 [security] prevent plaintext API key leak on keyring failure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `web_fetch` function in `src/askgem/tools/web_tools.py` directly uses `urllib.request.urlopen` with user-supplied URLs without validating the URL scheme.
 **Learning:** `urllib.request.urlopen` implicitly supports multiple schemes, including `file://`. If an application does not restrict schemes to `http://` and `https://`, an attacker can retrieve arbitrary local system files (like `/etc/passwd`) via local file read / Server-Side Request Forgery (SSRF).
 **Prevention:** Always validate and sanitize user-provided URLs before passing them to networking functions. Ensure URLs start with the expected protocol (e.g., `http://` or `https://`).
+
+## 2026-04-14 - Plaintext Storage of Search API Key on Keyring Failure
+**Vulnerability:** In `src/askgem/core/config_manager.py`, the `save_settings` method failed to remove sensitive API keys from the configuration dictionary if storing them in the system keyring encountered an exception. This resulted in the plaintext key being persisted to the `settings.json` file.
+**Learning:** When handling sensitive data that is intended for secure storage (like a keyring), always implement a fail-safe mechanism to ensure that the data is not leaked to less secure channels (like plaintext config files) if the primary secure storage method fails.
+**Prevention:** Explicitly clear sensitive keys from any objects destined for plaintext persistence within `except` blocks when attempting to move them to secure storage.

--- a/src/askgem/core/config_manager.py
+++ b/src/askgem/core/config_manager.py
@@ -75,6 +75,8 @@ class ConfigManager:
                 settings_to_save["google_search_api_key"] = "STORED_IN_KEYRING"
             except Exception as e:
                 self.console.print(f"[error][X] Error saving search key to keyring: {e}[/error]")
+                # Ensure the plaintext key is NOT saved to the JSON file on failure
+                settings_to_save["google_search_api_key"] = ""
 
         path = get_config_path(self.SETTINGS_FILE)
         try:

--- a/tests/core/test_config_manager_security.py
+++ b/tests/core/test_config_manager_security.py
@@ -1,0 +1,33 @@
+import json
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+from askgem.core.config_manager import ConfigManager
+
+def test_save_settings_does_not_leak_key_on_keyring_failure(tmp_path):
+    """
+    Verifies that the plaintext search key is NOT written to the config file
+    if keyring.set_password fails.
+    """
+    mock_console = MagicMock()
+    # We must ensure get_config_dir returns tmp_path so ConfigManager can write there.
+    with patch("askgem.core.config_manager.get_config_path") as mock_get_path:
+        settings_file = tmp_path / "settings.json"
+        mock_get_path.return_value = str(settings_file)
+
+        cm = ConfigManager(mock_console)
+        # Set a search key that needs to be moved to keyring
+        plaintext_key = "SUPER_SECRET_PLAINTEXT_KEY"
+        cm.settings["google_search_api_key"] = plaintext_key
+
+        # Mock keyring to fail
+        with patch("keyring.set_password", side_effect=Exception("Keyring failure")):
+            cm.save_settings()
+
+        # Read the saved settings file
+        with open(settings_file, "r") as f:
+            saved_settings = json.load(f)
+
+        # AFTER FIX: This should pass (it should not be equal to plaintext)
+        assert saved_settings["google_search_api_key"] != plaintext_key
+        assert saved_settings["google_search_api_key"] == ""


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `ConfigManager.save_settings` where sensitive API keys were persisted in plaintext to `settings.json` if the system keyring was unavailable or failed.

⚠️ **Risk:** If the system keyring service failed (e.g., due to configuration issues or missing dependencies), the application would fallback to saving the raw API key in the JSON configuration file, exposing it to any user or process with read access to the application's config directory.

🛡️ **Solution:** Implemented a fail-safe in the `except` block of the keyring storage logic. Now, if `keyring.set_password` fails, the `google_search_api_key` is explicitly set to an empty string in the dictionary destined for the JSON file, ensuring no plaintext credentials are leaked to disk. Added a dedicated security test case to verify this behavior.

---
*PR created automatically by Jules for task [15356368552684113763](https://jules.google.com/task/15356368552684113763) started by @julesklord*