### PR TITLE
🔒 Fix path traversal vulnerabilities in history manager

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The `web_fetch` function in `src/askgem/tools/web_tools.py` directly uses `urllib.request.urlopen` with user-supplied URLs without validating the URL scheme.
 **Learning:** `urllib.request.urlopen` implicitly supports multiple schemes, including `file://`. If an application does not restrict schemes to `http://` and `https://`, an attacker can retrieve arbitrary local system files (like `/etc/passwd`) via local file read / Server-Side Request Forgery (SSRF).
 **Prevention:** Always validate and sanitize user-provided URLs before passing them to networking functions. Ensure URLs start with the expected protocol (e.g., `http://` or `https://`).
+## 2024-04-14 - Path Traversal Vulnerability in Session Loading and Deletion
+**Vulnerability:** Path Traversal
+**Learning:** `os.path.join` does not inherently prevent path traversal if the injected path contains absolute path structures or traversal elements (`../`). Using user input directly as a filename without bounds checking allows arbitrary file read and delete operations outside the target directory.
+**Prevention:** Always combine `os.path.abspath` on both the target file path and the base directory. Then, validate the path remains within the intended boundary using `os.path.commonpath([base_dir, resolved_target_path]) == base_dir`.

--- a/src/askgem/core/history_manager.py
+++ b/src/askgem/core/history_manager.py
@@ -169,7 +169,11 @@ class HistoryManager:
         Returns:
             Optional[List[types.Content]]: The filtered message list, or None if invalid.
         """
-        filepath = os.path.join(self.history_dir, f"{session_id}.json")
+        filepath = os.path.abspath(os.path.join(self.history_dir, f"{session_id}.json"))
+        base_dir = os.path.abspath(self.history_dir)
+        if os.path.commonpath([base_dir, filepath]) != base_dir:
+            return None
+
         if not os.path.exists(filepath):
             return None
 
@@ -220,7 +224,11 @@ class HistoryManager:
         Returns:
             bool: True if targeted json existed and was unlinked, False otherwise.
         """
-        filepath = os.path.join(self.history_dir, f"{session_id}.json")
+        filepath = os.path.abspath(os.path.join(self.history_dir, f"{session_id}.json"))
+        base_dir = os.path.abspath(self.history_dir)
+        if os.path.commonpath([base_dir, filepath]) != base_dir:
+            return False
+
         try:
             if os.path.exists(filepath):
                 os.remove(filepath)

--- a/tests/core/test_history_manager.py
+++ b/tests/core/test_history_manager.py
@@ -51,24 +51,19 @@ class TestHistoryManager:
 
     def test_content_to_dict_function_call(self, manager):
         content = types.Content(
-            role="model",
-            parts=[types.Part.from_function_call(name="my_func", args={"arg1": "val1"})]
+            role="model", parts=[types.Part.from_function_call(name="my_func", args={"arg1": "val1"})]
         )
         result = manager._content_to_dict(content)
-        assert result == {
-            "role": "model",
-            "parts": [{"function_call": {"name": "my_func", "args": {"arg1": "val1"}}}]
-        }
+        assert result == {"role": "model", "parts": [{"function_call": {"name": "my_func", "args": {"arg1": "val1"}}}]}
 
     def test_content_to_dict_function_response(self, manager):
         content = types.Content(
-            role="user",
-            parts=[types.Part.from_function_response(name="my_func", response={"res1": "val1"})]
+            role="user", parts=[types.Part.from_function_response(name="my_func", response={"res1": "val1"})]
         )
         result = manager._content_to_dict(content)
         assert result == {
             "role": "user",
-            "parts": [{"function_response": {"name": "my_func", "response": {"res1": "val1"}}}]
+            "parts": [{"function_response": {"name": "my_func", "response": {"res1": "val1"}}}],
         }
 
     def test_dict_to_content_text(self, manager):
@@ -79,10 +74,7 @@ class TestHistoryManager:
         assert content.parts[0].text == "hello"
 
     def test_dict_to_content_function_call(self, manager):
-        data = {
-            "role": "model",
-            "parts": [{"function_call": {"name": "my_func", "args": {"arg1": "val1"}}}]
-        }
+        data = {"role": "model", "parts": [{"function_call": {"name": "my_func", "args": {"arg1": "val1"}}}]}
         content = manager._dict_to_content(data)
         assert content.role == "model"
         assert len(content.parts) == 1
@@ -91,10 +83,7 @@ class TestHistoryManager:
         assert "arg1" in content.parts[0].function_call.args
 
     def test_dict_to_content_function_response(self, manager):
-        data = {
-            "role": "user",
-            "parts": [{"function_response": {"name": "my_func", "response": {"res1": "val1"}}}]
-        }
+        data = {"role": "user", "parts": [{"function_response": {"name": "my_func", "response": {"res1": "val1"}}}]}
         content = manager._dict_to_content(data)
         assert content.role == "user"
         assert len(content.parts) == 1
@@ -211,3 +200,9 @@ class TestHistoryManager:
 
     def test_delete_session_not_exists(self, manager):
         assert manager.delete_session("nonexistent") is False
+
+    def test_load_session_path_traversal(self, manager):
+        assert manager.load_session("../../../etc/passwd") is None
+
+    def test_delete_session_path_traversal(self, manager):
+        assert manager.delete_session("../../../etc/passwd") is False


### PR DESCRIPTION
🎯 **What:** Fixed path traversal vulnerabilities in the `load_session` and `delete_session` methods of `HistoryManager`.

⚠️ **Risk:** An attacker or malicious input could provide a `session_id` like `../../../etc/passwd` allowing arbitrary file read or deletion on the host system outside of the intended history directory.

🛡️ **Solution:** Validated paths by constructing absolute paths and enforcing that `os.path.commonpath` strictly matches the intended base directory. If the boundary is crossed, the methods securely return `None` or `False`.

---
*PR created automatically by Jules for task [6913222568345985593](https://jules.google.com/task/6913222568345985593) started by @julesklord*