### PR TITLE
🎨 Palette: Add localized visual spinner for agent thinking state in CLI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -36,3 +36,7 @@
 ## 2026-04-14 - [Test Environment Configuration for Async Testing]
 **Learning:** Pytest doesn't natively support running `async def` test functions out of the box, throwing "async def functions are not natively supported" errors if a supporting plugin is not active. This can cause the CI to fail if the repository doesn't explicitly declare the async dependency.
 **Action:** Always ensure that `pytest-asyncio` (or a similar async test runner) is explicitly defined in `pyproject.toml` (e.g. within `[project.optional-dependencies]`) if the test suite utilizes `pytest.mark.asyncio` decorators.
+
+## 2025-05-19 - [Add Visual Loading State to CLI THINKING state]
+**Learning:** In CLI streaming applications using Rich, providing a visual loading indicator during the asynchronous `THINKING` phase (before token generation begins) improves UX by clearly signaling that the request is being processed. Failing to provide this feedback or properly cleaning up the state (e.g., stopping a spinner before transitioning to rendering code or tools) can lead to a confusing or visually corrupt user interface. Furthermore, hardcoding the loading text breaks internationalization.
+**Action:** Always add a visual spinner or loading text (using localized strings, e.g., `_("dashboard.prompt_thinking")`) when the agent enters the `THINKING` state, and ensure it is explicitly and cleanly stopped prior to transitioning to other output phases (like `thought`, `EXECUTING`, or `text`) as well as in a `finally` block.

--- a/src/askgem/agent/chat.py
+++ b/src/askgem/agent/chat.py
@@ -178,30 +178,39 @@ class ChatAgent:
         processed_input = self._process_input(user_input)
         config = self._build_config()
 
-        async for event in self.orchestrator.run_query(
-            processed_input, self.messages, config=config, confirmation_callback=renderer.ask_confirmation
-        ):
-            event_type = event.get("type")
-            status = event.get("status")
+        try:
+            async for event in self.orchestrator.run_query(
+                processed_input, self.messages, config=config, confirmation_callback=renderer.ask_confirmation
+            ):
+                event_type = event.get("type")
+                status = event.get("status")
 
-            if status == AgentTurnStatus.THINKING:
-                pass
-            elif status == AgentTurnStatus.EXECUTING:
-                for tc in event.get("tool_calls", []):
-                    renderer.print_tool_call(tc.name, tc.arguments)
-            elif event_type == "thought":
-                # Thoughts arrive before text — no Live active yet, safe to print directly
-                renderer.print_thought(event["content"])
-            elif event_type == "text":
-                # Start Live on first text chunk, not before
-                if not renderer._streaming:
-                    renderer.start_stream()
-                renderer.update_stream(event["content"])
-            elif event_type == "tool_result":
-                renderer.print_tool_result(not event["is_error"], event["content"])
-            elif event_type == "metrics":
-                u = event["usage"]
-                self.metrics.add_usage(u.input_tokens, u.output_tokens)
+                if status == AgentTurnStatus.THINKING:
+                    renderer.start_thinking_spinner()
+                elif status == AgentTurnStatus.EXECUTING:
+                    renderer.stop_thinking_spinner()
+                    for tc in event.get("tool_calls", []):
+                        renderer.print_tool_call(tc.name, tc.arguments)
+                elif event_type == "thought":
+                    renderer.stop_thinking_spinner()
+                    # Thoughts arrive before text — no Live active yet, safe to print directly
+                    renderer.print_thought(event["content"])
+                elif event_type == "text":
+                    renderer.stop_thinking_spinner()
+                    # Start Live on first text chunk, not before
+                    if not renderer._streaming:
+                        renderer.start_stream()
+                    renderer.update_stream(event["content"])
+                elif event_type == "tool_result":
+                    renderer.stop_thinking_spinner()
+                    renderer.print_tool_result(not event["is_error"], event["content"])
+                elif event_type == "error":
+                    renderer.stop_thinking_spinner()
+                elif event_type == "metrics":
+                    u = event["usage"]
+                    self.metrics.add_usage(u.input_tokens, u.output_tokens)
+        finally:
+            renderer.stop_thinking_spinner()
 
     async def start(self) -> None:
         """Rich CLI entry point — streaming renderer with code blocks and think panels."""

--- a/src/askgem/cli/renderer.py
+++ b/src/askgem/cli/renderer.py
@@ -24,8 +24,11 @@ from rich.markup import escape
 from rich.panel import Panel
 from rich.prompt import Confirm
 from rich.rule import Rule
+from rich.status import Status
 from rich.syntax import Syntax
 from rich.text import Text
+
+from ..core.i18n import _
 
 # ---------------------------------------------------------------------------
 # Segment parser
@@ -150,6 +153,7 @@ class CliRenderer:
         self.console = console
         self._live: Live | None = None
         self._streaming = False
+        self._thinking_status: Status | None = None
         self._last_text = ""
         self.username = getpass.getuser()
         self.apply_theme(theme_name)
@@ -204,7 +208,9 @@ class CliRenderer:
     # Agent label (printed once before streaming starts)
     # ------------------------------------------------------------------
     def _print_agent_label(self) -> None:
-        self.console.print(f"\n [bold {self.C_BRAND}]✨ @askgem[/]")
+        if not getattr(self, "_agent_label_printed", False):
+            self.console.print(f"\n [bold {self.C_BRAND}]✨ @askgem[/]")
+            self._agent_label_printed = True
 
     def print_thought(self, text: str) -> None:
         """Renders the reasoning process in a subtle, minimalist style."""
@@ -223,6 +229,19 @@ class CliRenderer:
     # ------------------------------------------------------------------
     # Live streaming (raw text, no parsing — fast, zero flicker)
     # ------------------------------------------------------------------
+    def start_thinking_spinner(self) -> None:
+        """Starts a visual spinner indicating the agent is thinking."""
+        if not self._thinking_status:
+            self._print_agent_label()
+            self._thinking_status = Status(_("dashboard.prompt_thinking"), console=self.console, spinner="dots")
+            self._thinking_status.start()
+
+    def stop_thinking_spinner(self) -> None:
+        """Stops the thinking spinner if it's running."""
+        if self._thinking_status:
+            self._thinking_status.stop()
+            self._thinking_status = None
+
     def start_stream(self) -> None:
         self._print_agent_label()
         self._live = Live(
@@ -244,6 +263,9 @@ class CliRenderer:
 
     def end_stream(self, full_text: str | None = None) -> None:
         """Stop Live and render the structured final response."""
+        if getattr(self, "_agent_label_printed", False):
+            self._agent_label_printed = False
+
         if not self._streaming:
             return
 
@@ -377,11 +399,13 @@ class CliRenderer:
             self._live = None
 
         if warning:
-            self.console.print(Panel(
-                f"[bold white]{warning}[/bold white]",
-                title="[bold yellow]⚠️ SECURITY WARNING[/bold yellow]",
-                border_style="red"
-            ))
+            self.console.print(
+                Panel(
+                    f"[bold white]{warning}[/bold white]",
+                    title="[bold yellow]⚠️ SECURITY WARNING[/bold yellow]",
+                    border_style="red",
+                )
+            )
         else:
             self.console.print(f"\n[bold {self.C_TOOL}]🛡  SECURITY CHECK[/]")
 


### PR DESCRIPTION
💡 What: Added a visual `rich.status.Status` spinner during the agent's `THINKING` state in the CLI.
🎯 Why: Without visual feedback, the terminal appeared frozen between the user's input and the first streaming token. This provides immediate, reassuring feedback that the agent is working.
📸 Before/After: Visual change in the CLI; users now see `AskGem is thinking...` with a dot spinner before token generation begins.
♿ Accessibility: Ensures that loading states are explicitly communicated and uses localized strings instead of hardcoded text.

---
*PR created automatically by Jules for task [1789656580753966043](https://jules.google.com/task/1789656580753966043) started by @julesklord*