### PR TITLE
🧪 [testing improvement] Add tests for analyze_command_safety whitelist fallbacks

### DIFF
--- a/tests/core/test_security.py
+++ b/tests/core/test_security.py
@@ -72,3 +72,31 @@ def test_ensure_safe_path(path, expected_valid):
     else:
         with pytest.raises(PermissionError):
             ensure_safe_path(path)
+
+
+def test_whitelist_fallback_paths():
+    """Verifies the various fallback paths in analyze_command_safety whitelist."""
+    # Matches whitelist exactly
+    report = analyze_command_safety("ls")
+    assert report.level == SafetyLevel.SAFE
+    assert report.category == "WHITELISTED"
+
+    # Starts with whitelist + space
+    report = analyze_command_safety("ls -la")
+    assert report.level == SafetyLevel.SAFE
+    assert report.category == "WHITELISTED"
+
+    # Has whitelist prefix but no space (should fallback to GENERIC_COMMAND)
+    report = analyze_command_safety("lsblk")
+    assert report.level == SafetyLevel.NOTICE
+    assert report.category == "GENERIC_COMMAND"
+
+    # Is in whitelist but has pipes (should be COMPLEX_COMMAND)
+    report = analyze_command_safety("ls | grep foo")
+    assert report.level == SafetyLevel.NOTICE
+    assert report.category == "COMPLEX_COMMAND"
+
+    # Completely unknown command (should fallback to GENERIC_COMMAND)
+    report = analyze_command_safety("my_custom_script.sh")
+    assert report.level == SafetyLevel.NOTICE
+    assert report.category == "GENERIC_COMMAND"


### PR DESCRIPTION
🎯 **What:** The testing gap in `analyze_command_safety`'s whitelist fallback logic was addressed. Previously, the logic around checking if a command is exactly a whitelisted command, starts with a whitelisted command, or falls back appropriately was not tested.
📊 **Coverage:** The new tests cover:
  - Exact whitelist matches (`ls`)
  - Whitelist prefix matches (`ls -la`)
  - Non-whitelist prefixes falling back to `GENERIC_COMMAND` (`lsblk`)
  - Whitelist commands containing pipes falling back to `COMPLEX_COMMAND` (`ls | grep foo`)
  - Completely unknown commands falling back to `GENERIC_COMMAND` (`my_custom_script.sh`)
✨ **Result:** Test coverage is improved, specifically covering all branching and fallback paths of the `_SAFE_COMMAND_WHITELIST` check in `src/askgem/core/security.py`, preventing future regressions.

---
*PR created automatically by Jules for task [4604047199041237729](https://jules.google.com/task/4604047199041237729) started by @julesklord*