### PR TITLE
🔒 [security: Validate and enforce HTTPS for dynamic OpenAI provider endpoints]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** Path Traversal
 **Learning:** `os.path.join` does not inherently prevent path traversal if the injected path contains absolute path structures or traversal elements (`../`). Using user input directly as a filename without bounds checking allows arbitrary file read and delete operations outside the target directory.
 **Prevention:** Always combine `os.path.abspath` on both the target file path and the base directory. Then, validate the path remains within the intended boundary using `os.path.commonpath([base_dir, resolved_target_path]) == base_dir`.
+
+## 2024-05-24 - SSRF and Credential Leak via Unvalidated External Endpoints
+**Vulnerability:** The OpenAI provider fetched dynamic endpoints from an external JSON source (models.dev/api.json) without validation. It directly trusted this string for the API base url, which allowed for Server-Side Request Forgery (SSRF) if a local endpoint (e.g. `http://127.0.0.1/v1`) was specified, and potential credential leakage if a non-HTTPS (e.g. `http://`) malicious URL was provided, as the API key is passed in the `Authorization` header.
+**Learning:** Always validate externally obtained dynamic URLs before initiating network requests, even if the external source is generally trusted, as sources can be compromised or hijacked.
+**Prevention:** Verify the URL is globally routable (using tools like `is_safe_url`) to prevent SSRF and strictly enforce HTTPS (`url.startswith("https://")`) when sending sensitive authentication headers like API keys.

--- a/src/mentask/agent/core/providers/openai.py
+++ b/src/mentask/agent/core/providers/openai.py
@@ -27,6 +27,7 @@ class OpenAIProvider(BaseProvider):
         """Resolves API Base and Key dynamically using models.dev metadata."""
 
         from ....core.models_hub import hub
+        from ....tools.web_tools import is_safe_url
 
         # 1. Try to find model info in the Hub
         info = hub.get_model(self.model_name)
@@ -46,8 +47,16 @@ class OpenAIProvider(BaseProvider):
 
             if provider_id and provider_id in providers:
                 p_info = providers[provider_id]
-                self.api_base = p_info.get("endpoint", self.api_base)
-                _logger.info(f"Resolved endpoint for {provider_id}: {self.api_base}")
+                candidate_endpoint = p_info.get("endpoint")
+
+                if candidate_endpoint:
+                    if candidate_endpoint.startswith("https://") and is_safe_url(candidate_endpoint):
+                        self.api_base = candidate_endpoint
+                        _logger.info(f"Resolved endpoint for {provider_id}: {self.api_base}")
+                    else:
+                        _logger.warning(
+                            f"Rejected unsafe or non-HTTPS endpoint for {provider_id}: {candidate_endpoint}"
+                        )
 
         # 2. Resolve API Key
         # Priority: Specific provider key via ConfigManager > Generic fallback

--- a/tests/test_openai_security.py
+++ b/tests/test_openai_security.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from mentask.agent.core.providers.openai import OpenAIProvider
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock()
+    config.load_api_key.return_value = "fake_key"
+    return config
+
+@pytest.mark.anyio
+async def test_openai_provider_safe_endpoint(mock_config):
+    """Test that a valid global HTTPS endpoint is accepted."""
+    provider = OpenAIProvider("fake_provider:model_x", mock_config)
+
+    with patch("mentask.core.models_hub.ModelsHub.get_model") as mock_get_model, \
+         patch("mentask.core.models_hub.hub._data", new_callable=dict) as mock_data, \
+         patch("mentask.tools.web_tools.is_safe_url", return_value=True):
+
+        mock_get_model.return_value = {"id": "model_x"}
+        mock_data.update({
+            "providers": {
+                "fake_provider": {
+                    "endpoint": "https://api.valid-global-provider.com/v1"
+                }
+            }
+        })
+
+        success = await provider.setup()
+
+        assert success is True
+        assert provider.api_base == "https://api.valid-global-provider.com/v1"
+
+@pytest.mark.anyio
+async def test_openai_provider_rejects_http(mock_config):
+    """Test that an HTTP endpoint is rejected, retaining default api_base."""
+    provider = OpenAIProvider("fake_provider:model_x", mock_config)
+
+    with patch("mentask.core.models_hub.ModelsHub.get_model") as mock_get_model, \
+         patch("mentask.core.models_hub.hub._data", new_callable=dict) as mock_data, \
+         patch("mentask.tools.web_tools.is_safe_url", return_value=True):
+
+        mock_get_model.return_value = {"id": "model_x"}
+        mock_data.update({
+            "providers": {
+                "fake_provider": {
+                    "endpoint": "http://api.insecure-provider.com/v1"
+                }
+            }
+        })
+
+        success = await provider.setup()
+
+        assert success is True
+        assert provider.api_base == "https://api.openai.com/v1"
+
+@pytest.mark.anyio
+async def test_openai_provider_rejects_unsafe_url(mock_config):
+    """Test that a URL failing is_safe_url (e.g. localhost/SSRF) is rejected."""
+    provider = OpenAIProvider("fake_provider:model_x", mock_config)
+
+    with patch("mentask.core.models_hub.ModelsHub.get_model") as mock_get_model, \
+         patch("mentask.core.models_hub.hub._data", new_callable=dict) as mock_data, \
+         patch("mentask.tools.web_tools.is_safe_url", return_value=False):
+
+        mock_get_model.return_value = {"id": "model_x"}
+        mock_data.update({
+            "providers": {
+                "fake_provider": {
+                    "endpoint": "https://127.0.0.1/v1"
+                }
+            }
+        })
+
+        success = await provider.setup()
+
+        assert success is True
+        assert provider.api_base == "https://api.openai.com/v1"


### PR DESCRIPTION
🎯 **What:** The OpenAI provider dynamically fetched endpoint URLs from an external models hub JSON and used them directly for network requests without validation.

⚠️ **Risk:** This allowed for Server-Side Request Forgery (SSRF) if a local endpoint (like http://localhost) was provided. It also allowed potential credential leakage over unencrypted HTTP since the API key is passed in the Authorization header.

🛡️ **Solution:** Implemented validation to ensure the candidate endpoint passes `is_safe_url()` and strictly starts with `https://`. Unsafe endpoints are rejected, falling back to the safe default.

---
*PR created automatically by Jules for task [2212623504797949550](https://jules.google.com/task/2212623504797949550) started by @julesklord*