### PR TITLE
🎨 Palette: Add thinking indicator to CLI

### DIFF
--- a/src/mentask/agent/chat.py
+++ b/src/mentask/agent/chat.py
@@ -247,9 +247,13 @@ class ChatAgent:
         self, renderer: "CliRenderer", status: AgentTurnStatus | None, event_type: str | None, event: dict[str, Any]
     ) -> None:
         if status == AgentTurnStatus.THINKING:
+            if hasattr(renderer, "start_thinking"):
+                renderer.start_thinking()
             return
 
         if status == AgentTurnStatus.EXECUTING:
+            if hasattr(renderer, "stop_thinking"):
+                renderer.stop_thinking()
             if renderer._streaming:
                 renderer.end_stream()
 
@@ -265,18 +269,24 @@ class ChatAgent:
             return
 
         if event_type == "thought":
+            if hasattr(renderer, "stop_thinking"):
+                renderer.stop_thinking()
             if renderer._streaming:
                 renderer.end_stream()
             renderer.print_thought(event["content"])
             return
 
         if event_type == "text":
+            if hasattr(renderer, "stop_thinking"):
+                renderer.stop_thinking()
             if not renderer._streaming:
                 renderer.start_stream(is_natural=True)
             renderer.update_stream(event["content"])
             return
 
         if event_type == "tool_result":
+            if hasattr(renderer, "stop_thinking"):
+                renderer.stop_thinking()
             renderer.print_tool_result(not event["is_error"], event["content"], tool_name=event.get("tool_name"))
             return
 
@@ -288,6 +298,8 @@ class ChatAgent:
             return
 
         if event_type == "error":
+            if hasattr(renderer, "stop_thinking"):
+                renderer.stop_thinking()
             renderer.print_error(event["content"])
             return
 

--- a/src/mentask/cli/gem_renderer.py
+++ b/src/mentask/cli/gem_renderer.py
@@ -19,9 +19,11 @@ from rich.markdown import Markdown
 from rich.markup import escape
 from rich.panel import Panel
 from rich.prompt import Confirm
+from rich.status import Status
 from rich.syntax import Syntax
 from rich.text import Text
 
+from ..core.i18n import _
 from .prompts import PromptEngine
 from .themes import get_theme
 
@@ -141,6 +143,7 @@ class GemStyleRenderer:
         self._last_metrics = ""
         self._last_stream_time = time.time()
         self.printed_count = 0  # Number of items in committed_buffer already printed definitively
+        self._status: Status | None = None
 
     def _setup_colors(self) -> None:
         self.C_BRAND = self.theme.brand_primary
@@ -161,6 +164,7 @@ class GemStyleRenderer:
         self._label_printed = False
         self.committed_buffer = []
         self.printed_count = 0
+        self.stop_thinking()
 
     # ─────────────────────────────────────────────────────────────────
     # Core Rendering
@@ -185,6 +189,24 @@ class GemStyleRenderer:
     # ─────────────────────────────────────────────────────────────────
     # Streaming
     # ─────────────────────────────────────────────────────────────────
+
+    def start_thinking(self) -> None:
+        """Shows a localized thinking spinner."""
+        if self._status:
+            return
+
+        self._status = self.console.status(
+            _("dashboard.prompt_thinking"),
+            spinner="dots",
+            spinner_style=f"bold {self.C_THINK}",
+        )
+        self._status.start()
+
+    def stop_thinking(self) -> None:
+        """Stops the thinking spinner."""
+        if self._status:
+            self._status.stop()
+            self._status = None
 
     def start_stream(self, is_natural: bool = False) -> None:
         """Initialize streaming WITHOUT transient mode — content persists in terminal."""
@@ -321,7 +343,7 @@ class GemStyleRenderer:
 
         # Design decision: Show more lines for tool results to avoid "collapsed" feel
         lines = content.strip().splitlines()
-        is_list = any(l.strip().startswith(("-", "*", "1.", " •", "Directory:")) for l in lines[:10])
+        is_list = any(line.strip().startswith(("-", "*", "1.", " •", "Directory:")) for line in lines[:10])
         is_diff = content.strip().startswith(("---", "+++", "@@"))
 
         # Expand if it's a list, diff, or short structured content (up to 100 lines)

--- a/src/mentask/locales/es.json
+++ b/src/mentask/locales/es.json
@@ -41,5 +41,6 @@
   "cmd.mode.current": "Modo de edición actual:",
   "cmd.mode.set": "Modo de edición establecido en:",
   "cmd.clear.success": "Historial de conversación limpiado.",
-  "cmd.usage.title": "Métricas de Consumo de Tokens"
+  "cmd.usage.title": "Métricas de Consumo de Tokens",
+  "dashboard.prompt_thinking": "mentask está pensando..."
 }


### PR DESCRIPTION
🎯 **What:** Added a visual 'thinking' spinner to the `GemStyleRenderer` to provide immediate feedback when the agent is reasoning.
💡 **Why:** Users need visual confirmation that the agent is active during the thinking phase, especially before text starts streaming.
♿ **Accessibility:** Uses a localized status message ("mentask is thinking...") that can be read by screen readers.
✅ **Verification:** Verified with a manual test script simulating the agent's turn lifecycle and ran the full `tox` test suite.

---
*PR created automatically by Jules for task [2196637379104048456](https://jules.google.com/task/2196637379104048456) started by @julesklord*