### PR TITLE
🧹 [Remove unused Any import in plugin_tools]

### DIFF
--- a/src/mentask/agent/tools/plugin_tools.py
+++ b/src/mentask/agent/tools/plugin_tools.py
@@ -1,5 +1,4 @@
 import ast
-from typing import Any
 
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
🎯 **What:** Removed unused `Any` import from `src/mentask/agent/tools/plugin_tools.py`.
💡 **Why:** Improves code maintainability by keeping the namespace clean and removing an unnecessary dependency.
✅ **Verification:** Verified by running `ruff check` (which passed with no issues) and the full test suite via `tox -e py312` (all 235 tests passed).
✨ **Result:** A cleaner file with no unused imports and all functionality intact.

---
*PR created automatically by Jules for task [10462240285895012347](https://jules.google.com/task/10462240285895012347) started by @julesklord*