### PR TITLE
🧹 [remove unused import urllib.parse in web_tools.py]

### DIFF
--- a/src/mentask/tools/web_tools.py
+++ b/src/mentask/tools/web_tools.py
@@ -1,13 +1,13 @@
 import asyncio
-import logging
-
-_logger = logging.getLogger("mentask")
 import ipaddress
 import json
+import logging
 import re
 import socket
-import urllib.parse
 import urllib.request
+
+_logger = logging.getLogger("mentask")
+
 
 # Pre-compiled regex patterns for performance
 RE_DDG_RESULTS = re.compile(


### PR DESCRIPTION
🎯 **What:** Removed unused `urllib.parse` import from `src/mentask/tools/web_tools.py` and grouped imports correctly.
💡 **Why:** To improve code clarity, maintainability and adhere to codebase formatting standards.
✅ **Verification:** Verified by checking with `ruff check` and running tests successfully using `tox -e py312 -- -k test_web_tools`.
✨ **Result:** A cleaner `web_tools.py` with only necessary imports properly sorted.

---
*PR created automatically by Jules for task [629444098848193207](https://jules.google.com/task/629444098848193207) started by @julesklord*