### PR TITLE
🧹 Remove unused imports in plugin_loader.py

### DIFF
--- a/src/mentask/core/plugin_loader.py
+++ b/src/mentask/core/plugin_loader.py
@@ -8,9 +8,7 @@ agent tools (plugins) from the user's workspace or global configuration.
 import importlib.util
 import inspect
 import logging
-import os
 import sys
-from pathlib import Path
 from typing import Any
 
 from ..agent.tools.base import BaseTool
@@ -24,7 +22,7 @@ class PluginLoader:
     def __init__(self, tool_registry: Any):
         """
         Initializes the loader with a reference to the active ToolRegistry.
-        
+
         Args:
             tool_registry: The active instance of agent.tools.base.ToolRegistry
         """
@@ -35,7 +33,7 @@ class PluginLoader:
         """
         Scans the plugins directory, loads valid Python modules, and registers
         any class inheriting from BaseTool into the ToolRegistry.
-        
+
         Returns:
             int: The number of plugins successfully loaded.
         """


### PR DESCRIPTION
🎯 **What:** Removed unused `os` and `pathlib.Path` imports and fixed whitespace in `src/mentask/core/plugin_loader.py`.
💡 **Why:** Reduces clutter, fixes linter warnings, and improves maintainability.
✅ **Verification:** Ran `ruff check` and full test suite with `tox -e py312`, no regressions found.
✨ **Result:** Cleaner code, no unused imports or trailing whitespaces.

---
*PR created automatically by Jules for task [12045465702899360651](https://jules.google.com/task/12045465702899360651) started by @julesklord*