### PR TITLE
🎨 Palette: Add fuzzy matching for slash commands

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,7 @@
 ## 2025-01-24 - Shortcut Discoverability in CLI
 **Learning:** Custom keyboard shortcuts in CLI applications (like Ctrl+O for artifact expansion) are easily forgotten once the initial welcome screen scrolls out of view. Providing persistent hints in the primary help menu and contextually within relevant UI components (like Panels) ensures these powerful features remain accessible to users.
 **Action:** Always include a "Shortcuts" footer or caption in the main help output and use Panel subtitles to reinforce shortcut availability during active interactions.
+
+## 2025-05-17 - Fuzzy Slash Command Matching
+**Learning:** Users often make typos when entering slash commands in a CLI (e.g., `/stat` instead of `/stats`). Providing immediate, fuzzy-matched suggestions (e.g., "Did you mean /stats?") reduces friction and prevents the frustration of "Unknown command" errors by guiding the user back to the correct path.
+**Action:** Implement fuzzy matching (e.g., using `difflib`) for all interactive CLI command parsers to provide helpful suggestions on mismatch.

--- a/src/mentask/agent/core/commands.py
+++ b/src/mentask/agent/core/commands.py
@@ -4,6 +4,7 @@ Slash command handling module for mentask.
 Parses and dispatches mid-conversation commands like /help, /model, /mode, etc.
 """
 
+import difflib
 import logging
 from typing import Any
 
@@ -138,7 +139,15 @@ class CommandHandler:
         elif command == "/init":
             return await self._cmd_init()
 
-        return f"[error]{_('cmd.unknown')} {command}[/error] {_('cmd.hint_help')}"
+        # Fuzzy matching for unknown commands
+        all_cmds = self.get_all_commands()
+        suggestions = difflib.get_close_matches(command, all_cmds, n=1, cutoff=0.6)
+
+        error_msg = f"[error]{_('cmd.unknown')} {command}[/error]"
+        if suggestions:
+            error_msg += f" [dim]Did you mean [bold cyan]{suggestions[0]}[/bold cyan]?[/dim]"
+
+        return f"{error_msg} {_('cmd.hint_help')}"
 
     def _cmd_help(self) -> Table:
         """Returns the help table as a Rich object."""

--- a/tests/agent/test_command_handler.py
+++ b/tests/agent/test_command_handler.py
@@ -22,6 +22,16 @@ def mock_agent():
 
 
 @pytest.mark.asyncio
+async def test_command_handler_fuzzy_suggestion(mock_agent):
+    """Verifies that a typoed command triggers a 'Did you mean' suggestion."""
+    handler = CommandHandler(mock_agent)
+    # /hel should suggest /help
+    res = await handler.execute("/hel")
+    assert "[error]" in res
+    assert "Did you mean [bold cyan]/help[/bold cyan]?" in res
+
+
+@pytest.mark.asyncio
 async def test_command_handler_help(mock_agent):
     """Verifies that /help command executes without error."""
     handler = CommandHandler(mock_agent)
@@ -45,10 +55,11 @@ async def test_command_handler_stop(mock_agent):
 
 @pytest.mark.asyncio
 async def test_command_handler_unknown(mock_agent):
-    """Verifies that unknown commands return None."""
+    """Verifies that unknown commands return a localized error message."""
     handler = CommandHandler(mock_agent)
     res = await handler.execute("/unknown_cmd_123")
-    assert res is None
+    assert "[error]" in res
+    assert "/unknown_cmd_123" in res
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
💡 **What:** Added fuzzy command suggestions for unknown slash commands in the CLI.
🎯 **Why:** Reduces user friction when typos occur (e.g., `/stat` -> `/stats`) and improves overall discoverability of commands.
♿ **Accessibility:** Provides immediate, helpful feedback for mistyped inputs instead of a generic error.
✨ **Result:** Users get intelligent suggestions when they make typos in the CLI, making the interface feel more polished and forgiving.

---
*PR created automatically by Jules for task [4050358175895092673](https://jules.google.com/task/4050358175895092673) started by @julesklord*