### PR TITLE
fix: prevent path traversal in _create_backup

### DIFF
--- a/src/mentask/tools/file_tools.py
+++ b/src/mentask/tools/file_tools.py
@@ -27,10 +27,13 @@ def _create_backup(path: str) -> str:
     # We want to preserve the relative path from CWD to the file in the backup
     try:
         rel_path = os.path.relpath(path, os.getcwd())
+        # Security: Prevent path traversal by ensuring rel_path doesn't escape backup_folder
+        if rel_path.startswith("..") or os.path.isabs(rel_path):
+            rel_path = os.path.basename(path)
     except ValueError:
         # Fallback if path is on a different drive or something weird
         rel_path = os.path.basename(path)
-    backup_path = backup_folder / rel_path
+    backup_path = (backup_folder / rel_path).resolve()
     # Ensure backup directory exists
     os.makedirs(os.path.dirname(backup_path), exist_ok=True)
     shutil.copy2(path, backup_path)

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -3,6 +3,7 @@ Tests for tools/file_tools.py — read_file and edit_file
 """
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -135,3 +136,33 @@ class TestFileSecurity:
         result = ensure_safe_path(rel_path)
         expected = str(tmp_path / rel_path)
         assert result == expected
+
+
+class TestBackupSecurity:
+    """Tests for path traversal in _create_backup."""
+
+    def test_create_backup_traversal_protection(self, tmp_path, monkeypatch):
+        from mentask.tools.file_tools import _create_backup
+
+        backups_root = tmp_path / "backups"
+        backups_root.mkdir()
+        monkeypatch.setattr("mentask.tools.file_tools.get_backups_dir", lambda: backups_root)
+
+        # File outside CWD
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("content")
+
+        # Mock CWD to something else
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
+        backup_path_str = _create_backup(str(outside_file))
+        backup_path = Path(backup_path_str)
+
+        # Should be inside backups_root/TIMESTAMP/outside.txt
+        # and NOT contain .. to reach outside.txt
+        assert backup_path.name == "outside.txt"
+        assert str(backups_root) in str(backup_path)
+        # Verify it doesn't have .. in it
+        assert ".." not in str(backup_path.relative_to(backups_root))


### PR DESCRIPTION
Sanitize the relative path used in backup creation to ensure it doesn't escape the intended backup directory. If a path is outside the CWD, we now fall back to using only the file's basename.

Added regression tests in tests/tools/test_file_tools.py.