### PR TITLE
🧹 [code health improvement description] Remove unused CliRenderer import alias

### DIFF
--- a/src/mentask/agent/chat.py
+++ b/src/mentask/agent/chat.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ..cli.gem_renderer import GemStyleRenderer as CliRenderer
+    from ..cli.gem_renderer import GemStyleRenderer
 
 from ..cli.console import console
 from ..cli.contextual_prompts import (
@@ -278,7 +278,7 @@ class ChatAgent:
                 ]
         return user_input
 
-    async def _stream_response(self, user_input: str, renderer: "CliRenderer") -> None:
+    async def _stream_response(self, user_input: str, renderer: "GemStyleRenderer") -> None:
         """Core logic: feeds input to orchestrator and updates UI."""
         renderer.reset_turn()
         processed_input = self._process_input(user_input)
@@ -292,7 +292,11 @@ class ChatAgent:
             self._handle_stream_event(renderer, status, event_type, event)
 
     def _handle_stream_event(
-        self, renderer: "CliRenderer", status: AgentTurnStatus | None, event_type: str | None, event: dict[str, Any]
+        self,
+        renderer: "GemStyleRenderer",
+        status: AgentTurnStatus | None,
+        event_type: str | None,
+        event: dict[str, Any],
     ) -> None:
         if status == AgentTurnStatus.THINKING:
             renderer.show_thinking()
@@ -433,7 +437,7 @@ class ChatAgent:
 
         return sessions, history_data, is_new
 
-    async def _handle_command_input(self, user_input: str, renderer: "CliRenderer") -> bool:
+    async def _handle_command_input(self, user_input: str, renderer: "GemStyleRenderer") -> bool:
         if not user_input.startswith("/"):
             return False
 
@@ -543,7 +547,7 @@ class ChatAgent:
         )
         self.active_renderer.console.print()
 
-    async def _handle_user_turn(self, user_input: str, renderer: "CliRenderer") -> None:
+    async def _handle_user_turn(self, user_input: str, renderer: "GemStyleRenderer") -> None:
         self.session_messages += 1
         renderer.reset_turn()
 

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,7 @@ wheels = [
 
 [[package]]
 name = "mentask"
-version = "0.26.1"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
🎯 **What:** Removed the unused `CliRenderer` import alias and replaced all type hint references with the actual `GemStyleRenderer` class name in `src/mentask/agent/chat.py`.

💡 **Why:** To improve code maintainability and readability by eliminating an unnecessary alias that was only used in stringified type hints. The `as CliRenderer` typing alias added cognitive overhead without providing value.

✅ **Verification:**
* Ran the full test suite (`tox -e py312`) to ensure no regressions were introduced.
* Executed `uv run ruff check` to ensure code passes linting without errors.
* Confirmed formatting using `uv run ruff format`.

✨ **Result:** A cleaner `TYPE_CHECKING` import block and straightforward type annotations in the `ChatAgent` class without any loss of functionality or performance.

---
*PR created automatically by Jules for task [10216760981686970077](https://jules.google.com/task/10216760981686970077) started by @julesklord*