### PR TITLE
🧪 [Add test for dirty directory in enter_worktree]

### DIFF
--- a/tests/tools/test_worktree_tools.py
+++ b/tests/tools/test_worktree_tools.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mentask.tools.worktree_tools import enter_worktree
+
+
+class TestEnterWorktree:
+    def test_dirty_directory_raises_error(self):
+        with patch("subprocess.run") as mock_run:
+            # Mock the return value of git status --porcelain
+            mock_run.return_value = MagicMock(stdout=" M some_file.py\n")
+
+            with pytest.raises(RuntimeError) as exc_info:
+                enter_worktree("test-branch")
+
+            assert "The working directory is dirty" in str(exc_info.value)
+            # Verify subprocess.run was called with correct arguments
+            mock_run.assert_called_once_with(
+                ["git", "status", "--porcelain"], capture_output=True, text=True, check=False
+            )


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `enter_worktree` when the git working directory is dirty (uncommitted changes exist).
📊 **Coverage:** Covered the error path in `enter_worktree` where it checks `git status --porcelain` and raises a `RuntimeError` if output exists.
✨ **Result:** Improved test reliability by ensuring the protection against executing git commands on a dirty working directory works correctly.

---
*PR created automatically by Jules for task [14587038297412688896](https://jules.google.com/task/14587038297412688896) started by @julesklord*