### PR TITLE
🧪 test: add exception fallback test for _detect_language

### DIFF
--- a/tests/core/test_i18n.py
+++ b/tests/core/test_i18n.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from unittest.mock import patch
+import locale
+import pytest
+
+from mentask.core.i18n import Translator
+
+def test_detect_language_exception_fallback():
+    """Test that _detect_language safely falls back to 'en' when an exception is raised."""
+    translator = Translator()
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch('locale.getdefaultlocale', side_effect=Exception("Test Exception")), \
+             patch('locale.getlocale', side_effect=Exception("Test Exception")):
+
+            lang = translator._detect_language()
+            assert lang == "en"


### PR DESCRIPTION
🎯 **What:** Adds unit test to cover exception fallback to 'en' in `Translator._detect_language` when `locale` modules raise exceptions.
📊 **Coverage:** Mocking locale modules to throw exception properly tests the safe fallback logic.
✨ **Result:** Enhanced test suite and coverage.

---
*PR created automatically by Jules for task [17955433685455375928](https://jules.google.com/task/17955433685455375928) started by @julesklord*