### PR TITLE
🧪 [Add tests for language detection in i18n module]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def is_ollama_running():
     try:
         response = requests.get("http://localhost:11434/api/tags")
         return response.status_code == 200
-    except:
+    except Exception:
         return False
 
 

--- a/tests/core/test_i18n.py
+++ b/tests/core/test_i18n.py
@@ -1,0 +1,51 @@
+import os
+from unittest.mock import patch
+
+from mentask.core.i18n import Translator
+
+
+def test_detect_language_env_lang():
+    translator = Translator()
+    with patch.dict(os.environ, {"LANG": "es_ES"}, clear=True):
+        assert translator._detect_language() == "es"
+
+def test_detect_language_env_lc_all():
+    translator = Translator()
+    with patch.dict(os.environ, {"LC_ALL": "fr_FR"}, clear=True):
+        assert translator._detect_language() == "fr"
+
+def test_detect_language_locale_getdefaultlocale():
+    translator = Translator()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("sys.version_info", (3, 10)),
+        patch("locale.getdefaultlocale", return_value=("de_DE", "UTF-8"), create=True),
+    ):
+        assert translator._detect_language() == "de"
+
+def test_detect_language_locale_getlocale():
+    translator = Translator()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("sys.version_info", (3, 11)),
+        patch("locale.getlocale", return_value=("it_IT", "UTF-8"), create=True),
+    ):
+        assert translator._detect_language() == "it"
+
+def test_detect_language_fallback():
+    translator = Translator()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("sys.version_info", (3, 11)),
+        patch("locale.getlocale", return_value=(None, None), create=True),
+    ):
+        assert translator._detect_language() == "en"
+
+def test_detect_language_exception():
+    translator = Translator()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("sys.version_info", (3, 11)),
+        patch("locale.getlocale", side_effect=Exception("Test Exception"), create=True),
+    ):
+        assert translator._detect_language() == "en"


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested `Translator._detect_language` method in `src/mentask/core/i18n.py`.
📊 **Coverage:** Covered all code paths in `_detect_language`, including evaluating environment variables (`LANG` and `LC_ALL`), branching system locale lookup (using both `locale.getdefaultlocale` and `locale.getlocale` depending on the Python version), exceptions during detection, and the default fallback.
✨ **Result:** Improved test coverage for the `i18n` module and guaranteed robust language locale detection without introducing regressions.

---
*PR created automatically by Jules for task [4951918210910556225](https://jules.google.com/task/4951918210910556225) started by @julesklord*