### PR TITLE
🧪 [Add tests for enter_worktree edge cases]

### DIFF
--- a/tests/tools/test_worktree_tools.py
+++ b/tests/tools/test_worktree_tools.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 import unittest
 from unittest.mock import MagicMock, patch
@@ -45,6 +44,46 @@ class TestWorktreeTools(unittest.TestCase):
         self.assertIn("Success", result)
         mock_chdir.assert_called_with("/repo/root")
         mock_run.assert_called()
+
+    @patch("subprocess.run")
+    def test_enter_worktree_dirty(self, mock_run):
+        # Mocking
+        mock_run.return_value = MagicMock(stdout=" M somefile.py")
+
+        # Call & Verify
+        with self.assertRaisesRegex(RuntimeError, "dirty"):
+            enter_worktree("test-branch")
+
+    @patch("subprocess.run")
+    @patch("subprocess.check_output")
+    @patch("os.makedirs")
+    @patch("os.chdir")
+    @patch("os.getcwd")
+    def test_enter_worktree_new_branch(self, mock_getcwd, mock_chdir, mock_makedirs, mock_check_output, mock_run):
+        # Mocking
+        mock_run.side_effect = [
+            MagicMock(stdout=""),  # git status
+            subprocess.CalledProcessError(
+                1, ["git", "rev-parse", "--verify", "test-branch"]
+            ),  # git rev-parse (branch does not exist)
+            MagicMock(),  # git worktree add
+        ]
+        mock_check_output.return_value = "/repo/root"
+
+        # Call
+        result = enter_worktree("test-branch")
+
+        # Verify
+        self.assertIn("Success", result)
+        self.assertIn("test-branch", result)
+        mock_chdir.assert_called()
+
+        mock_run.assert_any_call(
+            ["git", "worktree", "add", "-b", "test-branch", "/repo/root/.mentask/worktrees/test-branch"],
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing coverage for the dirty directory error condition and the new branch fallback path in the enter_worktree function.
📊 **Coverage:** Scenarios for a dirty working directory raising a RuntimeError and the correct invocation of git worktree add -b for a new branch are now tested.
✨ **Result:** Increased test coverage and confidence in the worktree creation logic.

---
*PR created automatically by Jules for task [8778473412971422957](https://jules.google.com/task/8778473412971422957) started by @julesklord*