### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/src/mentask/agent/chat.py
+++ b/src/mentask/agent/chat.py
@@ -281,9 +281,21 @@ class ChatAgent:
 
     def _process_input(self, user_input: str) -> str | list[dict[str, Any]]:
         """Detects if input is a file path and converts to multimodal Parts."""
-        path = Path(user_input.strip())
-        if path.exists() and path.is_file():
-            ext = path.suffix.lower()
+        raw_input = user_input.strip()
+        if not raw_input:
+            return user_input
+
+        safe_root = Path.cwd().resolve()
+        user_path = Path(raw_input)
+        candidate_path = (safe_root / user_path).resolve() if not user_path.is_absolute() else user_path.resolve()
+
+        try:
+            candidate_path.relative_to(safe_root)
+        except ValueError:
+            return user_input
+
+        if candidate_path.exists() and candidate_path.is_file():
+            ext = candidate_path.suffix.lower()
             # Media extensions supported by Gemini 2.0+
             media_exts = {
                 ".png": "image/png",
@@ -304,11 +316,11 @@ class ChatAgent:
                 # Read as bytes and wrap in inline_data Part
                 import base64
 
-                with open(path, "rb") as f:
+                with open(candidate_path, "rb") as f:
                     b64_data = base64.b64encode(f.read()).decode("utf-8")
 
                 return [
-                    {"text": f"Analyzing file: {path.name}"},
+                    {"text": f"Analyzing file: {candidate_path.name}"},
                     {"inline_data": {"mime_type": mime, "data": b64_data}},
                 ]
         return user_input


### PR DESCRIPTION
Potential fix for [https://github.com/pitahayaDevSoft/mentask.py/security/code-scanning/8](https://github.com/pitahayaDevSoft/mentask.py/security/code-scanning/8)

To fix this safely, validate and constrain file-path resolution to a trusted base directory before any filesystem access. The best minimal-change fix is in `src/mentask/agent/chat.py` inside `_process_input`:

- Resolve a safe root directory (use current working directory for compatibility).
- Resolve the user-provided path against that root and normalize it (`Path.resolve()`).
- Reject absolute/escaping paths by ensuring the resolved candidate is within the safe root via `relative_to`.
- Only then perform `exists()/is_file()/open()` checks on the validated path.
- Keep existing behavior (media extension filtering and inline encoding) unchanged for valid in-root paths.
- If validation fails, return original `user_input` (current behavior fallback).

No changes are required in `server.py` once sink-side validation is added in `chat.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
