### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/src/mentask/agent/chat.py
+++ b/src/mentask/agent/chat.py
@@ -287,14 +287,16 @@ class ChatAgent:
 
         safe_root = Path.cwd().resolve()
         user_path = Path(raw_input)
-        candidate_path = (safe_root / user_path).resolve() if not user_path.is_absolute() else user_path.resolve()
-
-        try:
-            candidate_path.relative_to(safe_root)
-        except ValueError:
+        if user_path.is_absolute():
             return user_input
 
-        if candidate_path.exists() and candidate_path.is_file():
+        try:
+            candidate_path = (safe_root / user_path).resolve(strict=True)
+            candidate_path.relative_to(safe_root)
+        except (ValueError, OSError, RuntimeError):
+            return user_input
+
+        if candidate_path.is_file():
             ext = candidate_path.suffix.lower()
             # Media extensions supported by Gemini 2.0+
             media_exts = {


### PR DESCRIPTION
Potential fix for [https://github.com/pitahayaDevSoft/mentask.py/security/code-scanning/11](https://github.com/pitahayaDevSoft/mentask.py/security/code-scanning/11)

Use strict canonicalization and containment validation against a trusted base directory before any filesystem access, and reject unsafe path forms early.

Best fix in `src/mentask/agent/chat.py` (inside `_process_input`):
1. Keep `safe_root = Path.cwd().resolve()`.
2. Reject absolute user paths immediately (only allow paths relative to workspace).
3. Build candidate path with `safe_root / user_path`, then resolve with `strict=True` to canonicalize and require existence.
4. Verify the resolved real path is still under `safe_root` via `relative_to`.
5. If any validation fails (`ValueError`, `OSError`, `RuntimeError`), return original input as plain text.
6. Keep existing media extension allowlist and file-type check.

This preserves functionality (users can still reference files in project tree) while preventing traversal/symlink escapes and satisfying both alert variants from HTTP and WebSocket sources.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
