### PR TITLE
Potential fix for code scanning alert no. 15: Uncontrolled data used in path expression

### DIFF
--- a/src/mentask/agent/chat.py
+++ b/src/mentask/agent/chat.py
@@ -297,7 +297,14 @@ class ChatAgent:
 
         safe_root = Path.cwd().resolve()
         user_path = Path(raw_input)
-        if user_path.is_absolute():
+
+        # Accept only simple local filenames (no directories/traversal/absolute paths).
+        # This prevents user-controlled path expressions from escaping the workspace.
+        if (
+            user_path.is_absolute()
+            or raw_input != user_path.name
+            or ".." in user_path.parts
+        ):
             return user_input
 
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/pitahayaDevSoft/mentask.py/security/code-scanning/15](https://github.com/pitahayaDevSoft/mentask.py/security/code-scanning/15)

Use strict input validation before creating/opening a path: only allow simple local filenames (no directory separators, no traversal segments), then resolve and enforce safe-root containment as a second guard. This keeps current behavior (auto-detecting media file references) while removing attacker control over arbitrary path expressions.

Best fix in `src/mentask/agent/chat.py` within `_process_input`:
- Add early checks on `raw_input` to reject:
  - absolute paths
  - paths containing parent traversal (`..`) or separator components
  - anything other than a plain filename (`Path(raw_input).name == raw_input`)
- Keep existing `resolve(strict=True)` + `relative_to(safe_root)` check as defense in depth.
- Keep media-extension allowlist and read logic unchanged.

No functional changes are required in `src/mentask/api/server.py`; both alert variants are fixed centrally by sanitizing in `_process_input`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
